### PR TITLE
Clean up gpg-sign and papertrail actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can also supply multiple space-separated filenames to sign a list of files:
 - name: "Create detached signature"
   uses: mongodb/drivers-github-tools/garasign/gpg-sign@main
   with:
-    filenames: somefile.ext someotherfile.txt
+    filenames: dist/*
     garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
     garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
     artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
@@ -87,6 +87,6 @@ By default it will create a "papertrail.txt" file in the current directory.
   with:
     product_name: Mongo Python Driver
     release_version: ${{ github.ref_name }}
-    filenames: $DIST_FILES
+    filenames: dist/*
     token: ${{ github.token }}
 ```

--- a/garasign/gpg-sign/action.yml
+++ b/garasign/gpg-sign/action.yml
@@ -2,7 +2,7 @@ name: "Sign artifact using garasign"
 description: "Signs a release artifact"
 inputs:
   filenames:
-    description: "File names to sign, space separated"
+    description: "File name(s) to sign, can be a glob pattern"
     required: true
   garasign_username:
     description: "Garasign username"

--- a/garasign/gpg-sign/action.yml
+++ b/garasign/gpg-sign/action.yml
@@ -54,5 +54,5 @@ runs:
           -v $(pwd):$(pwd) \
           -w $(pwd) \
           ${{ inputs.artifactory_registry }}/${{ inputs.artifactory_image }} \
-          /bin/bash -c 'gpgloader && for filename in "${{ inputs.filenames }}"; do gpg --detach-sign --armor --output ${filename}.sig ${filename}; done'
+          /bin/bash -c 'gpgloader && for filename in ${{ inputs.filenames }}; do gpg --detach-sign --armor --output ${filename}.sig ${filename}; done'
       shell: bash

--- a/papertrail/action.yml
+++ b/papertrail/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "The release version. If not provided, the github.ref_name variable will be used"
     required: false
   filenames:
-    description: "Artifact filenames to include in the report, space-separated"
+    description: "Artifact filename(s) to include in the report, can be a glob pattern"
     required: true
   token:
     description: "The GitHub token for the action"

--- a/papertrail/action.yml
+++ b/papertrail/action.yml
@@ -27,7 +27,7 @@ runs:
           NAME=$(gh api users/${{ github.actor }} --jq '.name')
           export PAPERTRAIL="${{ inputs.output }}"
           echo "Product: ${{ inputs.product_name }}" > $PAPERTRAIL
-          echo "Version: ${{ inputs.version }}" >> $PAPERTRAIL
+          echo "Version: ${{ inputs.release_version }}" >> $PAPERTRAIL
           echo "Releaser: $NAME"  >> $PAPERTRAIL
           echo "Build Source: GitHub Actions"
           echo "Build Number: ${{ github.run_id }}"

--- a/papertrail/action.yml
+++ b/papertrail/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "Releaser: $NAME"  >> $PAPERTRAIL
           echo "Build Source: GitHub Actions"
           echo "Build Number: ${{ github.run_id }}"
-          for filename in"${{ inputs.filenames }}"; do
+          for filename in ${{ inputs.filenames }}; do
               SHA=$(shasum -a 256 $filename | awk '{print $1;}')
               echo "Filename: $filename"  >> $PAPERTRAIL
               echo "Shasum: $SHA"  >> $PAPERTRAIL

--- a/papertrail/action.yml
+++ b/papertrail/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: "Name of product"
     required: true
   release_version:
-    description: "The release version. If not provided, the github.ref_name variable will be used"
-    required: false
+    description: "The release version"
+    required: true
   filenames:
     description: "Artifact filename(s) to include in the report, can be a glob pattern"
     required: true
@@ -26,12 +26,8 @@ runs:
           export GH_TOKEN=${{ inputs.token }}
           NAME=$(gh api users/${{ github.actor }} --jq '.name')
           export PAPERTRAIL="${{ inputs.output }}"
-          export VERSION="${{ github.ref_name }}"
-          if [ -n "${{ inputs.release_version }}" ]; then
-              export VERSION="${{ inputs.release_version }}"
-          fi
           echo "Product: ${{ inputs.product_name }}" > $PAPERTRAIL
-          echo "Version: $VERSION" >> $PAPERTRAIL
+          echo "Version: ${{ inputs.version }}" >> $PAPERTRAIL
           echo "Releaser: $NAME"  >> $PAPERTRAIL
           echo "Build Source: GitHub Actions"
           echo "Build Number: ${{ github.run_id }}"

--- a/papertrail/action.yml
+++ b/papertrail/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   output:
     description: "The output filename"
-    default: "papertail.txt"
+    default: "papertrail.txt"
 
 runs:
   using: composite


### PR DESCRIPTION
- Fix handling of multiple files, supporting glob patterns
- Require a release version for papertrail
- Typo fixes


Example run: https://github.com/blink1073/winkerberos/actions/runs/9024423244/job/24798319965