### PR TITLE
Fix copying signature files to release assets

### DIFF
--- a/gpg-sign/action.yml
+++ b/gpg-sign/action.yml
@@ -25,4 +25,4 @@ runs:
     - name: "Move the signature files to the release directory"
       shell: bash
       run: |
-        mv ${{inputs.filenames}}.sig $RELEASE_ASSETS
+        for filename in ${{ inputs.filenames }}; do mv ${filename}.sig $RELEASE_ASSETS; done


### PR DESCRIPTION
This fixes copying signature files to the release assets folder. It would work fine when calling gpg-sign with a single file name, but wouldn't copy all signature files when passing multiple file names (however, it probably worked when passing a single glob pattern)