### PR TITLE
Code Scanning Alert Documentation and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ This action will download an Augmented SBOM file in `$RELEASE_ASSETS/sbom.json`.
     silk_asset_group: mongodb-python-driver
 ```
 
+### Code Scanning Alerts
+
+This action will export all dismissed and open alerts to a SARIF file. By
+default, this file is named `code-scanning-alerts.json` and placed in the
+working directory.
+
+```yaml
+- name: Setup
+  uses: mongodb-labs/drivers-github-tools/setup@v2
+  with:
+    ...
+
+- name: Export Code Scanning Alerts
+  uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
+```
+
 ## Python Helper Scripts
 
 These scripts are opinionated helper scripts for Python releases.

--- a/code-scanning-export/dist/index.js
+++ b/code-scanning-export/dist/index.js
@@ -29289,7 +29289,10 @@ async function run() {
     const alerts = await (0, api_1.getAlerts)(repositoryInfo.owner, repositoryInfo.repo, ref, core.getInput('token'));
     core.info(`Found ${alerts.length} alerts, processing now...`);
     const sarifReport = (0, sarif_1.createSarifReport)(alerts);
-    const filePath = path.join(process.cwd(), core.getInput('output-file'));
+    const outputFile = core.getInput('output-file');
+    const filePath = path.isAbsolute(outputFile)
+        ? outputFile
+        : path.join(process.cwd(), outputFile);
     core.info(`Processing done, writing report to file ${filePath}`);
     fs.writeFileSync(filePath, JSON.stringify(sarifReport), {});
 }

--- a/code-scanning-export/src/main.ts
+++ b/code-scanning-export/src/main.ts
@@ -32,7 +32,10 @@ export async function run(): Promise<void> {
   core.info(`Found ${alerts.length} alerts, processing now...`)
 
   const sarifReport = createSarifReport(alerts)
-  const filePath = path.join(process.cwd(), core.getInput('output-file'))
+  const outputFile = core.getInput('output-file')
+  const filePath = path.isAbsolute(outputFile)
+    ? outputFile
+    : path.join(process.cwd(), outputFile)
 
   core.info(`Processing done, writing report to file ${filePath}`)
 


### PR DESCRIPTION
- Adds documentation for the `code-scanning-export` action
- Adds support for absolute `output-file` values in the action