### PR TITLE
Add action to upload S3 assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ working directory.
   uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
 ```
 
+## Upload S3 assets
+
+A number of scripts create files in the `tmp/s3_assets` folder, which then can
+be uploaded to the product's S3 bucket:
+
+```yaml
+- name: Setup
+  uses: mongodb-labs/drivers-github-tools/setup@v2
+  with:
+    ...
+
+- name: Upload S3 assets
+  uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+  with:
+    version: <release version>
+    product_name: <product_name>
+```
+
+Optionally, you can specify which files to upload using the `filenames` input.
+By default, all files in the S3 directory are uploaded.
+
 ## Python Helper Scripts
 
 These scripts are opinionated helper scripts for Python releases.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ be uploaded to the product's S3 bucket:
 ```
 
 Optionally, you can specify which files to upload using the `filenames` input.
-By default, all files in the S3 directory are uploaded.
+By default, all files in the S3 directory are uploaded. When the `dry_run` input
+is set to anything other than `false`, no files are uploaded, but instead the
+filename along with the resulting location in the bucket is printed.
 
 ## Python Helper Scripts
 

--- a/upload-s3-assets/action.yml
+++ b/upload-s3-assets/action.yml
@@ -8,9 +8,13 @@ inputs:
     description: "The name of the product"
     required: true
   filenames:
-    description: Files to upload - supports wildcards and glob patterns
+    description: "Files to upload - supports wildcards and glob patterns"
     default: '*'
     required: false
+  dry_run:
+    description: "Only print files that would be uploaded, but don't upload any files"
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -18,4 +22,8 @@ runs:
     - shell: bash
       working-directory: ${{ env.S3_ASSETS }}
       run: |
-        for filename in ${{ inputs.filenames }}; do aws s3 cp ${filename} s3://${AWS_BUCKET}/${{ inputs.product_name }}/${{ inputs.version }}/${filename}; done
+        if [ "${{ inputs.dry_run }}" == "false" ]; then
+          for filename in ${{ inputs.filenames }}; do aws s3 cp ${filename} s3://${AWS_BUCKET}/${{ inputs.product_name }}/${{ inputs.version }}/${filename}; done
+        else
+          for filename in ${{ inputs.filenames }}; do echo "Would upload ${filename} to ${{ inputs.product_name }}/${{ inputs.version }}/${filename}"; done
+        fi

--- a/upload-s3-assets/action.yml
+++ b/upload-s3-assets/action.yml
@@ -1,0 +1,21 @@
+name: Upload S3 assets
+description: Uploads assets from the S3 asset directory
+inputs:
+  version:
+    description: "The published version"
+    required: true
+  product_name:
+    description: "The name of the product"
+    required: true
+  filenames:
+    description: Files to upload - supports wildcards and glob patterns
+    default: '*'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ env.S3_ASSETS }}
+      run: |
+        for filename in ${{ inputs.filenames }}; do aws s3 cp ${filename} s3://${AWS_BUCKET}/${{ inputs.product_name }}/${{ inputs.version }}/${filename}; done


### PR DESCRIPTION
This action is similar to the one created for node in https://github.com/mongodb-labs/drivers-github-tools/pull/14, with a couple of notable differences:
- By default, it uploads all files in the S3 directory - the `filenames` input can be used to change this but the action will only upload assets from that temporary `s3_assets` directory
- There is no dry run mode

@baileympearson I haven't touched the node action, but it could be replaced with this one once the PR is merged.