### PR TITLE
Minor improvements to bump and tag actions

### DIFF
--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   version_bump_script:
     description: The version bump script
-    required: true
+    default: ''
   commit_template:
     description: The template for the git commit message
     default: "BUMP ${VERSION}"
@@ -21,6 +21,7 @@ runs:
   using: composite
   steps:
     - name: Set new version
+      if: ${{ inputs.version_bump_script != '' }}
       shell: bash -eux {0}
       run: |
         ${{ inputs.version_bump_script }} ${{ inputs.version }}

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         if [ ${{ inputs.push_commit }} == "true" ]; then
           git push origin
-          echo "### Pushed version bump: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Pushed version bump: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
         else
-          echo "### Created version bump (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Created version bump (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -28,20 +28,20 @@ runs:
     - name: Get the commit message
       shell: bash -eux {0}
       run: |
-        export VERSION=${{inputs.version}}
-        export COMMIT_MESSAGE=$(echo "${{inputs.commit_template}}" | envsubst)
+        export VERSION=${{ inputs.version }}
+        export COMMIT_MESSAGE=$(echo "${{ inputs.commit_template }}" | envsubst)
         echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_ENV
     - name: Commit the version bump
       uses: mongodb-labs/drivers-github-tools/git-sign@v2
       with:
-        command: git commit -a -m \"${{env.COMMIT_MESSAGE}}\" -s --gpg-sign=${{ env.GPG_KEY_ID }}
-        artifactory_image: ${{inputs.artifactory_image}}
+        command: git commit -a -m \"${{ env.COMMIT_MESSAGE }}\" -s --gpg-sign=${{ env.GPG_KEY_ID }}
+        artifactory_image: ${{ inputs.artifactory_image }}
     - name: Push the commit to the source branch
       shell: bash -eux {0}
       run: |
         if [ ${{ inputs.push_commit }} == "true" ]; then
           git push origin
-          echo "Pushed version bump: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Pushed version bump: ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         else
-          echo "Created version bump (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Created version bump (no push): ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -23,14 +23,14 @@ runs:
     - name: Get the tag
       shell: bash -eux {0}
       run: |
-        export VERSION=${{inputs.version}}
-        export TAG=$(echo "${{inputs.tag_template}}" | envsubst)
+        export VERSION=${{ inputs.version }}
+        export TAG=$(echo "${{ inputs.tag_template }}" | envsubst)
         echo "TAG=$TAG" >> $GITHUB_ENV
     - name: Get the tag message
       shell: bash -eux {0}
       run: |
-        export VERSION=${{inputs.version}}
-        export TAG_MESSAGE=$(echo "${{inputs.tag_message_template}}" | envsubst)
+        export VERSION=${{ inputs.version }}
+        export TAG_MESSAGE=$(echo "${{ inputs.tag_message_template }}" | envsubst)
         echo "TAG_MESSAGE=$TAG_MESSAGE" >> $GITHUB_ENV
     - name: Tag the version
       uses: mongodb-labs/drivers-github-tools/git-sign@v2
@@ -52,7 +52,7 @@ runs:
       run: |
         if [ ${{ inputs.push_tag }} == "true" ]; then
           git push origin --tags
-          echo "Pushed tag: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Pushed tag: ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         else
-          echo "Created tag (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Created tag (no push): ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: "${VERSION}"
   tag_message_template:
     description: The template for the git tag message
-    default: "BUMP ${VERSION}"
+    default: "Release ${VERSION}"
   push_tag:
     description: Whether to push the tag
     default: "true"

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -52,7 +52,7 @@ runs:
       run: |
         if [ ${{ inputs.push_tag }} == "true" ]; then
           git push origin --tags
-          echo "### Pushed tag: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Pushed tag: ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
         else
-          echo "### Created tag (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
+          echo "Created tag (no push): ${{inputs.version}}" >> $GITHUB_STEP_SUMMARY
         fi


### PR DESCRIPTION
This PR contains a few changes to the bump-version and tag-commit actions:
- Changed the default tag message to "Release ${VERSION}" instead of "BUMP ${VERSION}" - I assumed the latter was wrong as it's the same as the bump commit
- Changed output style of the "created commit/tag" messages to no longer appear as headings in the build output
- Made the `version_bump_script` input in `bump_version` optional - this can be useful to skip the bump step if it happens before (as is the case in PHP where we bump earlier to sanity-check the input before starting the release process)
- (nit) Cleaned up style of variable usage