### PR TITLE
Add Ruby-project-specific actions for publishing and cleanup

### DIFF
--- a/ruby/cleanup/action.yml
+++ b/ruby/cleanup/action.yml
@@ -14,21 +14,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: "Create temporary app token"
-      uses: actions/create-github-app-token@v1
-      id: app-token
+    - name: 'Check out the repository'
+      uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}
-
-    - name: "Store GitHub token in environment"
-      shell: bash
-      run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ env.GH_TOKEN }}
 
     - name: Delete the release
       shell: bash

--- a/ruby/cleanup/action.yml
+++ b/ruby/cleanup/action.yml
@@ -4,15 +4,12 @@ inputs:
   app_id:
     description: The APP_ID defined for this project
     required: true
-    type: string
   app_private_key:
     description: The APP_PRIVATE_KEY defined for this project
     required: true
-    type: string
   tag:
     description: The name of the tag (and release) to clean up
     required: true
-    type: string
 
 runs:
   using: composite

--- a/ruby/cleanup/action.yml
+++ b/ruby/cleanup/action.yml
@@ -17,8 +17,8 @@ runs:
     - name: 'Check out the repository'
       uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
       with:
-        app-id: ${{ inputs.app_id }}
-        private-key: ${{ inputs.app_private_key }}
+        app_id: ${{ inputs.app_id }}
+        private_key: ${{ inputs.app_private_key }}
 
     - name: Delete the release
       shell: bash

--- a/ruby/cleanup/action.yml
+++ b/ruby/cleanup/action.yml
@@ -1,0 +1,42 @@
+name: Dry-Run Cleanup
+description: Cleans up generated tag and release after a dry-run.
+inputs:
+  app_id:
+    description: The APP_ID defined for this project
+    required: true
+    type: string
+  app_private_key:
+    description: The APP_PRIVATE_KEY defined for this project
+    required: true
+    type: string
+  tag:
+    description: The name of the tag (and release) to clean up
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: "Create temporary app token"
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+
+    - name: "Store GitHub token in environment"
+      shell: bash
+      run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ env.GH_TOKEN }}
+
+    - name: Delete the release
+      shell: bash
+      run: "gh release delete ${{ inputs.tag }}"
+
+    - name: Delete the tag
+      shell: bash
+      run: "git push --delete origin ${{ inputs.tag }}"

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -41,8 +41,8 @@ runs:
     - name: Check out the repository
       uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
       with:
-        app-id: ${{ inputs.app_id }}
-        private-key: ${{ inputs.app_private_key }}
+        app_id: ${{ inputs.app_id }}
+        private_key: ${{ inputs.app_private_key }}
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -4,47 +4,36 @@ inputs:
   app_id:
     description: The APP_ID defined for this project
     required: true
-    type: string
   app_private_key:
     description: The APP_PRIVATE_KEY defined for this project
     required: true
-    type: string
   aws_role_arn:
     description: The AWS_ROLE_ARN defined for this project
     required: true
-    type: string
   aws_region_name:
     description: The AWS_REGION_NAME defined for this project
     required: true
-    type: string
   aws_secret_id:
     description: The AWS_SECRET_ID defined for this project
     required: true
-    type: string
   dry_run:
     description: Whether this is a dry run or not ("false" for releases)
     required: true
-    type: string
   gem_name:
     description: The name (sans extension) of the gemspec file (e.g. "mongo")
     required: true
-    type: string
   product_name:
     description: The name of the product being published (e.g. "Ruby Driver")
     required: true
-    type: string
   product_id:
     description: The identifier of the product being published (e.g. "mongo-ruby-driver")
     required: true
-    type: string
   release_message_template:
     description: The template for the release message. Use "{0}" in the text to refer to the current version.
     required: true
-    type: string
   silk_asset_group:
     description: The Silk asset group for the project
     required: true
-    type: string
 
 runs:
   using: composite

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -38,21 +38,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: "Create temporary app token"
-      uses: actions/create-github-app-token@v1
-      id: app-token
+    - name: Check out the repository
+      uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}
-
-    - name: "Store GitHub token in environment"
-      shell: bash
-      run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ env.GH_TOKEN }}
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
@@ -86,38 +76,20 @@ runs:
       with:
         filenames: '${{ env.GEM_FILE_NAME }}'
 
-    - name: Generate authorized publication Documentation
-      uses: mongodb-labs/drivers-github-tools/authorized-pub@v2
+    - name: Generate SSDLC Reports
+      uses: mongodb-labs/drivers-github-tools/full-report@v2
       with:
         product_name: ${{ inputs.product_name }}
         release_version: ${{ env.RELEASE_VERSION }}
-        filenames: ${{ env.GEM_FILE_NAME }}
-        token: ${{ env.GH_TOKEN }}
+        dist_filenames: ${{ env.GEM_FILE_NAME }}
+        silk_asset_group: $${ inputs.silk_asset_group }}
 
-    - name: Download SBOM file from Silk
-      uses: mongodb-labs/drivers-github-tools/sbom@v2
+    - name: Create the tag
+      uses: mongodb-labs/drivers-github-tools/tag-version@v2
       with:
-        silk_asset_group: ${{ inputs.silk_asset_group }}
-
-    - name: Generate Sarif Report
-      uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
-      with:
-        output-file: ${{ env.S3_ASSETS }}/code-scanning-alerts.json
-
-    - name: Generate Compliance Report
-      uses: mongodb-labs/drivers-github-tools/compliance-report@v2
-      with:
-        token: ${{ env.GH_TOKEN }}
-
-    - name: Create and sign the tag
-      uses: mongodb-labs/drivers-github-tools/git-sign@v2
-      with:
-        command: "git tag -u ${{ env.GPG_KEY_ID }} -m 'Release tag for v${{ env.RELEASE_VERSION }}' v${{ env.RELEASE_VERSION }}"
-
-    - name: Push the tag to the repository
-      shell: bash
-      run: |
-        git push origin v${{ env.RELEASE_VERSION }}
+        version: ${{ env.RELEASE_VERSION }}
+        tag_template: "v${VERSION}"
+        tag_message_template: "Release tag for v${VERSION}"
 
     - name: Create a new release
       shell: bash

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -1,0 +1,167 @@
+name: Publish Ruby
+description: Generate and publish gems, signatures, and assets for MongoDB Ruby projects
+inputs:
+  app_id:
+    description: The APP_ID defined for this project
+    required: true
+    type: string
+  app_private_key:
+    description: The APP_PRIVATE_KEY defined for this project
+    required: true
+    type: string
+  aws_role_arn:
+    description: The AWS_ROLE_ARN defined for this project
+    required: true
+    type: string
+  aws_region_name:
+    description: The AWS_REGION_NAME defined for this project
+    required: true
+    type: string
+  aws_secret_id:
+    description: The AWS_SECRET_ID defined for this project
+    required: true
+    type: string
+  dry_run:
+    description: Whether this is a dry run or not ("false" for releases)
+    required: true
+    type: string
+  gem_name:
+    description: The name (sans extension) of the gemspec file (e.g. "mongo")
+    required: true
+    type: string
+  product_name:
+    description: The name of the product being published (e.g. "Ruby Driver")
+    required: true
+    type: string
+  product_id:
+    description: The identifier of the product being published (e.g. "mongo-ruby-driver")
+    required: true
+    type: string
+  release_message_template:
+    description: The template for the release message. Use "{0}" in the text to refer to the current version.
+    required: true
+    type: string
+  silk_asset_group:
+    description: The Silk asset group for the project
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: "Create temporary app token"
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+
+    - name: "Store GitHub token in environment"
+      shell: bash
+      run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ env.GH_TOKEN }}
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+
+    - name: Get the release version
+      shell: bash
+      run: echo "RELEASE_VERSION=$(rake version)" >> "$GITHUB_ENV"
+
+    - name: Setup GitHub tooling for DBX Drivers
+      uses: mongodb-labs/drivers-github-tools/setup@v2
+      with:
+        aws_role_arn: ${{ inputs.aws_role_arn }}
+        aws_region_name: ${{ inputs.aws_region_name }}
+        aws_secret_id: ${{ inputs.aws_secret_id }}
+
+    - name: Set output gem file name
+      shell: bash
+      run: |
+        echo "GEM_FILE_NAME=${{ inputs.gem_name }}-${{ env.RELEASE_VERSION }}.gem" >> "$GITHUB_ENV"
+
+    - name: Build the gem
+      shell: bash
+      run: |
+        gem build --output=${{ env.GEM_FILE_NAME }} ${{ inputs.gem_name }}.gemspec
+
+    - name: Sign the gem
+      uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+      with:
+        filenames: '${{ env.GEM_FILE_NAME }}'
+
+    - name: Generate authorized publication Documentation
+      uses: mongodb-labs/drivers-github-tools/authorized-pub@v2
+      with:
+        product_name: ${{ inputs.product_name }}
+        release_version: ${{ env.RELEASE_VERSION }}
+        filenames: ${{ env.GEM_FILE_NAME }}
+        token: ${{ env.GH_TOKEN }}
+
+    - name: Download SBOM file from Silk
+      uses: mongodb-labs/drivers-github-tools/sbom@v2
+      with:
+        silk_asset_group: ${{ inputs.silk_asset_group }}
+
+    - name: Generate Sarif Report
+      uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
+      with:
+        output-file: ${{ env.S3_ASSETS }}/code-scanning-alerts.json
+
+    - name: Generate Compliance Report
+      uses: mongodb-labs/drivers-github-tools/compliance-report@v2
+      with:
+        token: ${{ env.GH_TOKEN }}
+
+    - name: Create and sign the tag
+      uses: mongodb-labs/drivers-github-tools/git-sign@v2
+      with:
+        command: "git tag -u ${{ env.GPG_KEY_ID }} -m 'Release tag for v${{ env.RELEASE_VERSION }}' v${{ env.RELEASE_VERSION }}"
+
+    - name: Push the tag to the repository
+      shell: bash
+      run: |
+        git push origin v${{ env.RELEASE_VERSION }}
+
+    - name: Create a new release
+      shell: bash
+      run: gh release create v${{ env.RELEASE_VERSION }} --title ${{ env.RELEASE_VERSION }} --generate-notes --draft
+
+    - name: Capture the changelog
+      shell: bash
+      run: gh release view v${{ env.RELEASE_VERSION }} --json body --template '{{ .body }}' >> changelog
+
+    - name: Prepare release message
+      shell: bash
+      run: |
+        echo "${{ format(inputs.release_message_template, env.RELEASE_VERSION) }}" > release-message
+        cat changelog >> release-message
+
+    - name: Update release information
+      shell: bash
+      run: |
+        echo "RELEASE_URL=$(gh release edit v${{ env.RELEASE_VERSION }} --notes-file release-message)" >> "$GITHUB_ENV"
+
+    - name: Upload release artifacts
+      shell: bash
+      run: gh release upload v${{ env.RELEASE_VERSION }} ${{ env.GEM_FILE_NAME }} ${{ env.RELEASE_ASSETS }}/${{ env.GEM_FILE_NAME }}.sig
+
+    - name: Upload S3 assets
+      uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+      with:
+        version: ${{ env.RELEASE_VERSION }}
+        product_name: ${{ inputs.product_id }}
+        dry_run: ${{ inputs.dry_run }}
+
+    - name: Publish the gem
+      uses: rubygems/release-gem@v1
+      if: inputs.dry_run == 'false'
+      with:
+        await-release: false

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -82,7 +82,7 @@ runs:
         product_name: ${{ inputs.product_name }}
         release_version: ${{ env.RELEASE_VERSION }}
         dist_filenames: ${{ env.GEM_FILE_NAME }}
-        silk_asset_group: $${ inputs.silk_asset_group }}
+        silk_asset_group: ${{ inputs.silk_asset_group }}
 
     - name: Create the tag
       uses: mongodb-labs/drivers-github-tools/tag-version@v2

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Get the release version
       shell: bash
-      run: echo "RELEASE_VERSION=$(rake version)" >> "$GITHUB_ENV"
+      run: echo "RELEASE_VERSION=$(bundle exec rake version)" >> "$GITHUB_ENV"
 
     - name: Setup GitHub tooling for DBX Drivers
       uses: mongodb-labs/drivers-github-tools/setup@v2


### PR DESCRIPTION
This adds two new actions, specific to Ruby projects:

* `drivers-github-tools/ruby/publish`: this performs the full publication pipeline, including generating the SBOM file and other release documents, building and signing the ruby gem, drafting the GitHub release, and publishing the gem to RubyGems.
* `drivers-github-tools/ruby/cleanup`: Given a tag, this will delete the tag and corresponding release. It is intended to be used in conjunction with the `dry-run` option for `publish`, allowing faster interation during testing of these actions.