### PR TITLE
Fix handling of evergreen project

### DIFF
--- a/compliance-report/generate.sh
+++ b/compliance-report/generate.sh
@@ -26,6 +26,8 @@ if [ -n "$EVERGREEN_PROJECT" ]; then
     echo "Must supply an evergreen commit when supplying an evergreen project!"
     exit 1
   fi
+  # Format evergreen patch URL.
+  EVERGREEN_PROJECT=$(echo $EVERGREEN_PROJECT | sed 's/-/_/g')
   EVERGREEN_PATCH="Evergreen patch: https://spruce.mongodb.com/version/${EVERGREEN_PROJECT}_${EVERGREEN_COMMIT}"
 fi
 


### PR DESCRIPTION
e.g. `mongo-python-driver` ends up as `mongo_python_driver` and `pymongo-auth-aws` ends up as `pymongo_auth_aws` in the Evergreen URL.

https://spruce.mongodb.com/version/mongo_python_driver_8fbf84d314d18c2ce6e897e5d1bdd21f2493e409/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC