### PR TITLE
Fix default dependency tool handling

### DIFF
--- a/full-report/action.yml
+++ b/full-report/action.yml
@@ -16,6 +16,7 @@ inputs:
     description: The Silk Asset Group for the Project
   third_party_dependency_tool:
     description: The name of the tool used to track 3rd party dependencies.
+    default: Silk
   evergreen_project:
     description: The evergreen project name.
   evergreen_commit:


### PR DESCRIPTION
It was getting overridden to an empty string when running the full report.