### PR TITLE
Add python GitHub Attestations

### DIFF
--- a/python/publish/action.yml
+++ b/python/publish/action.yml
@@ -81,14 +81,14 @@ runs:
         PRODUCT_NAME: ${{ inputs.product_name }}
         DRY_RUN: ${{ inputs.dry_run }}
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
-    # - name: Publish distribution 📦 to PyPI
-    #   if: inputs.dry_run == 'false'
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    # - name: Do Not Publish distribution 📦 to PyPI on Dry Run
-    #   if: inputs.dry_run == 'true'
-    #   shell: bash
-    #   run: |
-    #     echo "Dry run, not uploading to PyPI" >> $GITHUB_STEP_SUMMARY
+    - name: Publish distribution 📦 to PyPI
+      if: inputs.dry_run == 'false'
+      uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Do Not Publish distribution 📦 to PyPI on Dry Run
+      if: inputs.dry_run == 'true'
+      shell: bash
+      run: |
+        echo "Dry run, not uploading to PyPI" >> $GITHUB_STEP_SUMMARY
     - uses: actions/attest-build-provenance@v1
       if: inputs.dry_run == 'false'
       with:

--- a/python/publish/action.yml
+++ b/python/publish/action.yml
@@ -81,14 +81,14 @@ runs:
         PRODUCT_NAME: ${{ inputs.product_name }}
         DRY_RUN: ${{ inputs.dry_run }}
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
-    - name: Publish distribution 📦 to PyPI
-      if: inputs.dry_run == 'false'
-      uses: pypa/gh-action-pypi-publish@release/v1
-    - name: Do Not Publish distribution 📦 to PyPI on Dry Run
-      if: inputs.dry_run == 'true'
-      shell: bash
-      run: |
-        echo "Dry run, not uploading to PyPI" >> $GITHUB_STEP_SUMMARY
+    # - name: Publish distribution 📦 to PyPI
+    #   if: inputs.dry_run == 'false'
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    # - name: Do Not Publish distribution 📦 to PyPI on Dry Run
+    #   if: inputs.dry_run == 'true'
+    #   shell: bash
+    #   run: |
+    #     echo "Dry run, not uploading to PyPI" >> $GITHUB_STEP_SUMMARY
     - uses: actions/attest-build-provenance@v1
       if: inputs.dry_run == 'false'
       with:

--- a/python/publish/action.yml
+++ b/python/publish/action.yml
@@ -89,6 +89,15 @@ runs:
       shell: bash
       run: |
         echo "Dry run, not uploading to PyPI" >> $GITHUB_STEP_SUMMARY
+    - uses: actions/attest-build-provenance@v1
+      if: inputs.dry_run == 'false'
+      with:
+        subject-path: dist/*
+    - uses: actions/attest-sbom@v1
+      if: inputs.dry_run == 'false'
+      with:
+        subject-path: dist/*
+        sbom-path: ${{ env.RELEASE_ASSETS }}/cyclonedx.sbom.json
     - name: Ensure a clean repo
       shell: bash
       run: |


### PR DESCRIPTION
Fixes #51.

We will need to update the Python release workflows to add the `attestations: write` permission.

Tested with https://github.com/blink1073/winkerberos/actions/runs/10060854177