### PR TITLE
Fix handling of cloud tags in go publish

### DIFF
--- a/golang/publish/forum.md.tmpl
+++ b/golang/publish/forum.md.tmpl
@@ -2,9 +2,9 @@
 
 The MongoDB Go Driver Team is pleased to release version {{ .ReleaseVersion }} of the \[MongoDB Go Driver](https://github.com/mongodb/mongo-go-driver).
 
-This release {description of notable changes}. For more information please see the \[{{ .ReleaseVersion }} release notes](https://github.com/mongodb/mongo-go-driver/releases/tag/v{{ .ReleaseVersion }}).
+This release {description of notable changes}. For more information please see the \[{{ .ReleaseVersion }} release notes](https://github.com/mongodb/mongo-go-driver/releases/tag/{{ .ReleaseVersion }}).
 
-You can obtain the driver source from GitHub under the \[v{{ .ReleaseVersion }} tag](https://github.com/mongodb/mongo-go-driver/tree/v{{ .ReleaseVersion }}).
+You can obtain the driver source from GitHub under the \[{{ .ReleaseVersion }} tag](https://github.com/mongodb/mongo-go-driver/tree/{{ .ReleaseVersion }}).
 
 Documentation for the Go driver can be found on \[pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo?tab=doc) and the
 \[MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/).

--- a/golang/publish/github.md.tmpl
+++ b/golang/publish/github.md.tmpl
@@ -18,6 +18,6 @@ For a full list of tickets included in this release, please see the links below:
 * [Bugs](https://jira.mongodb.org/issues/?jql=project%3DGODRIVER%20and%20type%3DBug%20and%20status%3Dclosed%20and%20fixVersion%3D{{ .ReleaseVersion }})
 * [Tasks](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20type%3D%22task%22%20and%20status%20%3D%20Closed%20and%20fixVersion%3D{{ .ReleaseVersion }})
 
-**Full Changelog**: [v{{ .PreviousVersion }}...v{{ .ReleaseVersion }}](https://github.com/mongodb/mongo-go-driver/compare/v{{ .PreviousVersion }}...v{{ .ReleaseVersion }})
+**Full Changelog**: [{{ .PreviousVersion }}...{{ .ReleaseVersion }}](https://github.com/mongodb/mongo-go-driver/compare/{{ .PreviousVersion }}...{{ .ReleaseVersion }})
 
 Documentation for the Go driver can be found on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo?tab=doc) and the [MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/). BSON library documentation is also available on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/bson?tab=doc). Questions and inquiries can be asked on the [MongoDB Developer Community](https://community.mongodb.com/). Bugs can be reported in the [Go Driver project in the MongoDB JIRA](https://jira.mongodb.org/secure/CreateIssue!default.jspa?pid=14289) where a list of [current issues](https://jira.mongodb.org/browse/GODRIVER) can be found. Your feedback on the Go driver is greatly appreciated!

--- a/golang/publish/publish.sh
+++ b/golang/publish/publish.sh
@@ -9,7 +9,7 @@ else
 fi
 echo "DRY_RUN=$DRY_RUN" >> $GITHUB_ENV
 
-# Handle cloud release versions
+# Get the tag names, taking into account cloud releases
 TAG_NAME="v${VERSION}"
 PREV_TAG_NAME="v${PREV_VERSION}"
 if [[ "${TAG_NAME}" =~ ^cloud.* ]]; then

--- a/golang/publish/publish.sh
+++ b/golang/publish/publish.sh
@@ -9,8 +9,16 @@ else
 fi
 echo "DRY_RUN=$DRY_RUN" >> $GITHUB_ENV
 
+# Handle cloud release versions
+TAG_NAME="v${VERSION}"
+PREV_TAG_NAME="v${PREV_VERSION}"
+if [[ "${TAG_NAME}" =~ ^cloud.* ]]; then
+  TAG_NAME="${VERSION}"
+  PREV_TAG_NAME="${PREV_VERSION}"
+fi
+
 # Generate notes
-go run notes.go $VERSION $PREV_VERSION
+go run notes.go $TAG_NAME $PREV_TAG_NAME
 cat forum.md >> $GITHUB_STEP_SUMMARY
 rm forum.md
 
@@ -22,12 +30,12 @@ NOTES_FILE=$(pwd)/github.md
 if [ "$PUSH_CHANGES" == "true" ]; then
     pushd $GITHUB_WORKSPACE || exit 1
     TITLE="MongoDB Go Driver ${VERSION}"
-    gh release create v${VERSION} --draft --verify-tag --title "$TITLE" -F $NOTES_FILE
-    gh release upload v${VERSION} $RELEASE_ASSETS/*.*
+    gh release create ${TAG_NAME} --draft --verify-tag --title "$TITLE" -F $NOTES_FILE
+    gh release upload ${TAG_NAME} $RELEASE_ASSETS/*.*
     JSON="url,tagName,assets,author,createdAt"
     JQ='.url,.tagName,.author.login,.createdAt,.assets[].name'
     echo "\## $TITLE" >> $GITHUB_STEP_SUMMARY
-    gh release view --json $JSON --jq $JQ v${VERSION} >> $GITHUB_STEP_SUMMARY
+    gh release view --json $JSON --jq $JQ ${TAG_NAME} >> $GITHUB_STEP_SUMMARY
     popd || exit 1
 else
     echo "## Skipping draft release with notes:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Addresses this bug:

https://github.com/mongodb/mongo-go-driver/actions/runs/11218783286/job/31183817541

```
gh release create vcloud-1.17-cloud2 --draft --verify-tag --title 'MongoDB Go Driver cloud-1.17-cloud2' -F /home/runner/work/_actions/mongodb-labs/drivers-github-tools/v2/golang/publish/github.md
[480](https://github.com/mongodb/mongo-go-driver/actions/runs/11218783286/job/31183817541#step:4:491)
~/work/mongo-go-driver/mongo-go-driver ~/work/_actions/mongodb-labs/drivers-github-tools/v2/golang/publish
[481](https://github.com/mongodb/mongo-go-driver/actions/runs/11218783286/job/31183817541#step:4:492)
tag vcloud-1.17-cloud2 doesn't exist in the repo mongodb/mongo-go-driver, aborting due to --verify-tag flag
```