### PR TITLE
fix(NODE-6587): adjust Node's actions to work with npm package scopes

### DIFF
--- a/node/get_version_info/action.yml
+++ b/node/get_version_info/action.yml
@@ -14,5 +14,7 @@ runs:
       run: |
         package_version=$(jq --raw-output '.version' package.json)
         echo "package_version=${package_version}" >> "$GITHUB_ENV"
-        echo "package_file=${{ inputs.npm_package_name }}-${package_version}.tgz" >> "$GITHUB_ENV"
+        npm pack
+        PACKFILE=$(ls *.tgz)
+        echo "package_file=$PACKFILE" >> "$GITHUB_ENV"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_ENV

--- a/node/sign_node_package/action.yml
+++ b/node/sign_node_package/action.yml
@@ -55,7 +55,7 @@ runs:
       if: ${{ inputs.sign_native == 'true' }}
       shell: bash
       run: |
-        FILENAMES="build-*/*.tar.gz"
+        FILENAMES="build-*/**/*.tar.gz"
         if [[ $FILENAMES =~ '*' ]]; then
           FILENAMES=$(ls $FILENAMES | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g')
         fi


### PR DESCRIPTION
The "get version info" action should pack the package and use the package file npm generates, instead of calculating the package file itself
The build and sign action should look in nested directories to account for package scopes when determining what native builds to sign.
