### PR TITLE
Move twine check to dedicated step

### DIFF
--- a/python/publish/action.yml
+++ b/python/publish/action.yml
@@ -84,6 +84,10 @@ runs:
         PRODUCT_NAME: ${{ inputs.product_name }}
         DRY_RUN: ${{ inputs.dry_run }}
         FOLLOWING_VERSION: ${{ inputs.following_version }}
+    - name: Check using twine
+      # TODO: remove as part of #62.
+      shell: bash
+      run: pipx run twine check dist/*.*
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
     - name: Publish distribution 📦 to PyPI
       if: inputs.dry_run == 'false'
@@ -91,6 +95,7 @@ runs:
       uses: pypa/gh-action-pypi-publish@v1.11.0
       with:
         repository-url: ${{ inputs.repository_url }}
+        verify-metadata: false
     - name: Do Not Publish distribution 📦 to PyPI on Dry Run
       if: inputs.dry_run == 'true'
       shell: bash


### PR DESCRIPTION
Because of #62, we are stuck with an older version of twine when using `gh-action-pypi-publish`, so use the latest twine to run the check, which supports packaging metadata version 2.4.

Addresses failure seen in pymongocrypt release: https://github.com/mongodb/libmongocrypt/actions/runs/12551349971/job/34995728032

