### PR TITLE
Revert "Move twine check to dedicated step"

### DIFF
--- a/python/publish/action.yml
+++ b/python/publish/action.yml
@@ -84,10 +84,6 @@ runs:
         PRODUCT_NAME: ${{ inputs.product_name }}
         DRY_RUN: ${{ inputs.dry_run }}
         FOLLOWING_VERSION: ${{ inputs.following_version }}
-    - name: Check using twine
-      # TODO: remove as part of #62.
-      shell: bash
-      run: pipx run twine check dist/*.*
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
     - name: Publish distribution 📦 to PyPI
       if: inputs.dry_run == 'false'
@@ -95,7 +91,6 @@ runs:
       uses: pypa/gh-action-pypi-publish@v1.11.0
       with:
         repository-url: ${{ inputs.repository_url }}
-        verify-metadata: false
     - name: Do Not Publish distribution 📦 to PyPI on Dry Run
       if: inputs.dry_run == 'true'
       shell: bash


### PR DESCRIPTION
Reverts mongodb-labs/drivers-github-tools#66

This had no effect, since using the same version of twine fails at the upload step: https://github.com/mongodb/libmongocrypt/actions/runs/12551349971/job/35001994941