### PR TITLE
Pin version of hatch used

### DIFF
--- a/python/pre-publish/action.yml
+++ b/python/pre-publish/action.yml
@@ -34,7 +34,8 @@ runs:
     - name: Install hatch
       shell: bash
       working-directory: ${{ inputs.working_directory }}
-      run: pipx install hatch
+      # TODO: remove when #62 is fixed.
+      run: pipx install "hatch<1.27"
     - name: Check if we should push changes
       shell: bash
       run: |


### PR DESCRIPTION
Revamp of #66 to instead install a version of hatch that writes core metadata 2.3, which is compatible with the version of twine used with `gh-action-pypi-publish@v1.11.0`.