### PR TITLE
Config options for Ruby `publish` action

### DIFF
--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -19,7 +19,7 @@ inputs:
   bundler_cache_version:
     description: The cache-version to use for the bundler cache
     required: false
-    default: 0
+    default: '0'
   dry_run:
     description: Whether this is a dry run or not ("false" for releases)
     required: true


### PR DESCRIPTION
This PR adds configuration options for specifying the Rubygems version to use (now defaults to `latest`, to avoid using the system Rubygems installation), and for specifying the bundler cache version (defaults to '0', which is the behavior you'd get if you didn't specify it at all).

This was necessary to work around an odd deployment issue that surfaced when trying to invoke the `rubygems/release-gem` action.