### PR TITLE
chore(NODE-6663): remove npm cache

### DIFF
--- a/node/setup/action.yml
+++ b/node/setup/action.yml
@@ -11,7 +11,6 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
-        cache: "npm"
         registry-url: "https://registry.npmjs.org"
     - run: npm install -g npm@latest
       shell: bash


### PR DESCRIPTION
Removes npm caching from the Node setup action.