### PR TITLE
GODRIVER-3537: Update release templates for the Go Driver

### DIFF
--- a/golang/publish/forum.md.tmpl
+++ b/golang/publish/forum.md.tmpl
@@ -6,13 +6,13 @@ This release {description of notable changes}. For more information please see t
 
 You can obtain the driver source from GitHub under the \[v{{ .ReleaseVersion }} tag](https://github.com/mongodb/mongo-go-driver/tree/v{{ .ReleaseVersion }}).
 
-Documentation for the Go driver can be found on \[pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo?tab=doc) and the
+Documentation for the Go Driver can be found on \[pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo?tab=doc) and the
 \[MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/).
-BSON library documentation is also available on \[pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/bson?tab=doc).
-Questions and inquiries can be asked on the \[MongoDB Developer Community](https://community.mongodb.com/).
+BSON library documentation is also available on \[pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/bson?tab=doc).
+Questions and inquiries can be asked on the \[MongoDB Developer Community](https://www.mongodb.com/community/forums/tag/golang).
 Bugs can be reported in the \[Go Driver project in the MongoDB JIRA](https://jira.mongodb.org/secure/CreateIssue!default.jspa?pid=14289)
 where a list of \[current issues](https://jira.mongodb.org/browse/GODRIVER) can be found.
-Your feedback on the Go driver is greatly appreciated!
+Your feedback on the Go Driver is greatly appreciated!
 
 Thank you,\
 The Go Driver Team

--- a/golang/publish/github.md.tmpl
+++ b/golang/publish/github.md.tmpl
@@ -1,4 +1,4 @@
-The MongoDB Go Driver Team is pleased to release version {{ .ReleaseVersion }} of the official MongoDB Go driver.
+The MongoDB Go Driver Team is pleased to release version {{ .ReleaseVersion }} of the official MongoDB Go Driver.
 
 ## Release Notes
 
@@ -20,4 +20,4 @@ For a full list of tickets included in this release, please see the links below:
 
 **Full Changelog**: [v{{ .PreviousVersion }}...v{{ .ReleaseVersion }}](https://github.com/mongodb/mongo-go-driver/compare/v{{ .PreviousVersion }}...v{{ .ReleaseVersion }})
 
-Documentation for the Go driver can be found on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo?tab=doc) and the [MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/). BSON library documentation is also available on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/bson?tab=doc). Questions and inquiries can be asked on the [MongoDB Developer Community](https://community.mongodb.com/). Bugs can be reported in the [Go Driver project in the MongoDB JIRA](https://jira.mongodb.org/secure/CreateIssue!default.jspa?pid=14289) where a list of [current issues](https://jira.mongodb.org/browse/GODRIVER) can be found. Your feedback on the Go driver is greatly appreciated!
+Documentation for the Go Driver can be found on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo?tab=doc) and the [MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/). BSON library documentation is also available on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/bson?tab=doc). Questions and inquiries can be asked on the [MongoDB Developer Community](https://www.mongodb.com/community/forums/tag/golang). Bugs can be reported in the [Go Driver project in the MongoDB JIRA](https://jira.mongodb.org/secure/CreateIssue!default.jspa?pid=14289) where a list of [current issues](https://jira.mongodb.org/browse/GODRIVER) can be found. Your feedback on the Go Driver is greatly appreciated!


### PR DESCRIPTION
This PR changes the release templates for the Go Driver:
* Use v2 links for pkg.go.dev
* Always capitalise "Go Driver"
* Use the correct link for the MongoDB Community