### PR TITLE
Simplify issue links for Go Driver releases

### DIFF
--- a/golang/publish/github.md.tmpl
+++ b/golang/publish/github.md.tmpl
@@ -10,13 +10,7 @@ This release {description of notable changes}.
 
 ***
 
-For a full list of tickets included in this release, please see the links below:
-
-* [Projects](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20type%3Depic%20and%20status%20%3D%20Closed%20and%20fixVersion%3D{{ .ReleaseVersion }})
-* [New Features](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20type%3D%22new%20feature%22%20and%20status%20%3D%20Closed%20and%20fixVersion%3D{{ .ReleaseVersion }})
-* [Improvements](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20type%3Dimprovement%20and%20status%20%3D%20Closed%20and%20fixVersion%3D{{ .ReleaseVersion }})
-* [Bugs](https://jira.mongodb.org/issues/?jql=project%3DGODRIVER%20and%20type%3DBug%20and%20status%3Dclosed%20and%20fixVersion%3D{{ .ReleaseVersion }})
-* [Tasks](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20type%3D%22task%22%20and%20status%20%3D%20Closed%20and%20fixVersion%3D{{ .ReleaseVersion }})
+For a full list of tickets included in this release, please see the [list of fixed issues](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20fixVersion%3D{{ .ReleaseVersion }}).
 
 **Full Changelog**: [v{{ .PreviousVersion }}...v{{ .ReleaseVersion }}](https://github.com/mongodb/mongo-go-driver/compare/v{{ .PreviousVersion }}...v{{ .ReleaseVersion }})
 


### PR DESCRIPTION
Instead of using multiple links for issue types, we now link to a single list of issues in the corresponding fixVersion.