### PR TITLE
Automatically merge up release commit on pre-release

### DIFF
--- a/golang/pre-publish/action.yml
+++ b/golang/pre-publish/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: "Determine branch to merge up to"
       if: ${{ inputs.push_changes }}
       id: get-next-branch
-      uses: alcaeus/automatic-merge-up-action/get-next-branch@main
+      uses: alcaeus/automatic-merge-up-action/get-next-branch@b253eae7dfccc0b637edf71121608375e07a7678 #main
       with:
         ref: ${{ github.ref_name }}
         branchNamePattern: 'release/<major>.<minor>'

--- a/golang/pre-publish/action.yml
+++ b/golang/pre-publish/action.yml
@@ -16,8 +16,30 @@ runs:
         version: ${{ inputs.version }}
         version_bump_script: "go run ${{ github.action_path }}/bump-version.go"
         commit_template: "BUMP v${VERSION}"
-        push_commit: ${{ inputs.push_changes }}
+        # Never push commit, we still need to merge up if a push is requested
+        push_commit: false
     - uses: mongodb-labs/drivers-github-tools/tag-version@v2
       with:
         version: v${{ inputs.version }}
         push_tag: ${{ inputs.push_changes }}
+    - name: "Determine branch to merge up to"
+      if: ${{ inputs.push_changes }}
+      id: get-next-branch
+      uses: alcaeus/automatic-merge-up-action/get-next-branch@main
+      with:
+        ref: ${{ github.ref_name }}
+        branchNamePattern: 'release/<major>.<minor>'
+        devBranchNamePattern: 'v<major>'
+        fallbackBranch: 'master'
+    - name: "Manually merge up changes"
+      if: ${{ inputs.push_changes && steps.get-next-branch.outputs.hasNextBranch }}
+      shell: bash
+      run: |
+        git checkout ${NEXT_BRANCH}
+        git merge --strategy=ours ${RELEASE_BRANCH}
+        git push origin ${NEXT_BRANCH}
+        git checkout ${RELEASE_BRANCH}
+        git push origin ${RELEASE_BRANCH}
+      env:
+        NEXT_BRANCH: ${{ steps.get-next-branch.outputs.branchName }}
+        RELEASE_BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
This change integrates the automatic-merge-up-action into the Go pre-release process.

If no push is requested, the behaviour does not change. However, when a push is requested, we determine the next branch (e.g. release/2.2 when releasing a 2.1 patch release) and merge the changes using the `ours` strategy. This marks the bump commit as fully merged up without accepting its changes. This removes the need for manually handling the merge-up pull request created due to pushing the new commit during the release process.