### PR TITLE
bump-version should use --set-upstream for new branches

### DIFF
--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -47,7 +47,7 @@ runs:
           if git ls-remote --heads --exit-code origin "$(git symbolic-ref --short HEAD)" &>/dev/null; then
             git push origin
           else
-            git push --set-upstream origin v4.13
+            git push --set-upstream origin "$(git symbolic-ref --short HEAD)"
           fi
           echo "Pushed version bump: ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         else

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -44,7 +44,11 @@ runs:
       shell: bash -eux {0}
       run: |
         if [ ${{ inputs.push_commit }} == "true" ]; then
-          git push origin
+          if git ls-remote --heads --exit-code origin "$(git symbolic-ref --short HEAD)" &>/dev/null; then
+            git push origin
+          else
+            git push --set-upstream origin v4.13
+          fi
           echo "Pushed version bump: ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         else
           echo "Created version bump (no push): ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
bump-verison fails if the branch it's on was freshly created: https://github.com/mongodb/mongo-python-driver/actions/runs/15533920823/job/43728612457. Adding --set-upstream for branches that are not yet tracked by the remote origin resolves this issue.