### PR TITLE
Go: Use generated release notes in GitHub Release template

### DIFF
--- a/golang/publish/github.md.tmpl
+++ b/golang/publish/github.md.tmpl
@@ -1,17 +1,7 @@
 The MongoDB Go Driver Team is pleased to release version {{ .ReleaseVersion }} of the official MongoDB Go Driver.
 
-## Release Notes
-
-This release {description of notable changes}.
-
-### {Notable Release Feature 1}
-
-{Description of notable release feature 1}
-
-***
+{{ .ChangeLog }}
 
 For a full list of tickets included in this release, please see the [list of fixed issues](https://jira.mongodb.org/issues/?jql=project%3Dgodriver%20and%20fixVersion%3D{{ .ReleaseVersion }}).
-
-**Full Changelog**: [v{{ .PreviousVersion }}...v{{ .ReleaseVersion }}](https://github.com/mongodb/mongo-go-driver/compare/v{{ .PreviousVersion }}...v{{ .ReleaseVersion }})
 
 Documentation for the Go Driver can be found on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo?tab=doc) and the [MongoDB documentation site](https://docs.mongodb.com/ecosystem/drivers/go/). BSON library documentation is also available on [pkg.go.dev](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/bson?tab=doc). Questions and inquiries can be asked on the [MongoDB Developer Community](https://www.mongodb.com/community/forums/tag/golang). Bugs can be reported in the [Go Driver project in the MongoDB JIRA](https://jira.mongodb.org/secure/CreateIssue!default.jspa?pid=14289) where a list of [current issues](https://jira.mongodb.org/browse/GODRIVER) can be found. Your feedback on the Go Driver is greatly appreciated!

--- a/golang/publish/notes.go
+++ b/golang/publish/notes.go
@@ -18,8 +18,12 @@ var forumTmpl string
 // for a Github release and writes it to a file named "github.md". It
 // also prints the gh command to create a new draft release with those release
 // notes.
-func generateGithubNotes(release, previous string) {
+func generateGithubNotes(release, previous, changeLogFile string) {
 	filename := "github.md"
+	changeLog, err := ioutil.ReadFile(changeLogFile)
+	if err != nil {
+		log.Fatalf("Error reading file %q: %v", changeLogFile, err)
+	}
 
 	writeTemplate(
 		filename,
@@ -27,6 +31,7 @@ func generateGithubNotes(release, previous string) {
 		map[string]any{
 			"ReleaseVersion":  release,
 			"PreviousVersion": previous,
+			"ChangeLog":       string(changeLog),
 		})
 
 	fmt.Println()
@@ -88,6 +93,7 @@ func writeTemplate(filename, tmplText string, data any) {
 func main() {
 	version := os.Args[1]
 	prevVersion := os.Args[2]
-	generateGithubNotes(version, prevVersion)
+	changeLogFile := os.Args[3]
+	generateGithubNotes(version, prevVersion, changeLogFile)
 	generateForumNotes(version)
 }

--- a/golang/publish/publish.sh
+++ b/golang/publish/publish.sh
@@ -9,28 +9,42 @@ else
 fi
 echo "DRY_RUN=$DRY_RUN" >> $GITHUB_ENV
 
-# Generate notes
-go run notes.go $VERSION $PREV_VERSION
-cat forum.md >> $GITHUB_STEP_SUMMARY
-rm forum.md
-
-echo "---" >> $GITHUB_STEP_SUMMARY
-
-NOTES_FILE=$(pwd)/github.md
-
 # Handle GitHub Release
 if [ "$PUSH_CHANGES" == "true" ]; then
     pushd $GITHUB_WORKSPACE || exit 1
     TITLE="MongoDB Go Driver ${VERSION}"
-    gh release create v${VERSION} --draft --verify-tag --title "$TITLE" -F $NOTES_FILE
+
+    # Create draft release with generated release notes
+    gh release create v${VERSION} --draft --verify-tag --title "$TITLE" --generate-notes
+
+    # Extract generated release notes to file
+    gh release view v${VERSION} --json body --template '{{ .body }}' >> changelog
+
+    NOTES_FILE=$(pwd)/changelog
+
+    popd || exit 1
+
+    # Generate release notes
+    go run notes.go $VERSION $PREV_VERSION $NOTES_FILE
+    cat forum.md >> $GITHUB_STEP_SUMMARY
+    rm forum.md
+
+    echo "---" >> $GITHUB_STEP_SUMMARY
+
+    NOTES_FILE=$(pwd)/github.md
+
+    pushd $GITHUB_WORKSPACE || exit 1
+
+    # Update release notes with generated version and upload release assets
+    gh release create v${VERSION} -F $NOTES_FILE
     gh release upload v${VERSION} $RELEASE_ASSETS/*.*
     JSON="url,tagName,assets,author,createdAt"
     JQ='.url,.tagName,.author.login,.createdAt,.assets[].name'
     echo "\## $TITLE" >> $GITHUB_STEP_SUMMARY
     gh release view --json $JSON --jq $JQ v${VERSION} >> $GITHUB_STEP_SUMMARY
+
     popd || exit 1
 else
-    echo "## Skipping draft release with notes:" >> $GITHUB_STEP_SUMMARY
-    cat $NOTES_FILE >> $GITHUB_STEP_SUMMARY
+    echo "## Skipping draft release" >> $GITHUB_STEP_SUMMARY
 fi
 rm $NOTES_FILE


### PR DESCRIPTION
This PR changes the release flow for Go. It now creates a draft release using the `--generate-notes` flag, which instructs GitHub to automatically generate release notes based on tags and configuration in the repository. We then extract those release notes from the tag and use them in the full notes that we then write to the release later.

Due to the generated changelog being required, the dry run no longer contains forum and GitHub release notes in the job output -- although this could be worked around if we so desire.