### PR TITLE
DRIVERS-3232 Move ECR login to before Assuming Team Role

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -23,6 +23,17 @@ inputs:
 runs:
   using: composite
   steps:
+  # Docker login must be done before input role login so we remain logged in for S3 upload.
+  - name: configure aws credentials for ECR
+    uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+    with:
+      role-to-assume: ${{ inputs.ecr_role_arn }}
+      role-session-name: release-session
+      aws-region: ${{ inputs.ecr_region }}
+  - name: Log in to ECR
+    uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+    with:
+      registries: "${{ inputs.ecr_registry_id }}"
   - name: configure aws credentials
     uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
     with:
@@ -41,13 +52,3 @@ runs:
     run: ${{ github.action_path }}/setup.sh
     env:
       AWS_SECRET_ID: ${{ inputs.aws_secret_id }}
-  - name: configure aws credentials for ECR
-    uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-    with:
-      role-to-assume: ${{ inputs.ecr_role_arn }}
-      role-session-name: release-session
-      aws-region: ${{ inputs.ecr_region }}
-  - name: Log in to ECR
-    uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
-    with:
-      registries: "${{ inputs.ecr_registry_id }}"


### PR DESCRIPTION
In this [build](https://github.com/mongodb/pymongo-auth-aws/actions/runs/17839288327/job/50724515819) we successfully uploaded to S3.  There is a separate failure in the python script after the upload that I will address separately.


```
Completed 384 Bytes/384 Bytes (719 Bytes/s) with 1 file(s) remaining
upload: ./authorized-publication.txt to s3://***/pymongo-auth-aws/1.4.0.dev1/authorized-publication.txt
Completed 87 Bytes/87 Bytes (280 Bytes/s) with 1 file(s) remaining
upload: ./code-scanning-alerts.json to s3://***/pymongo-auth-aws/1.4.0.dev1/code-scanning-alerts.json
Completed 1.5 KiB/1.5 KiB (4.9 KiB/s) with 1 file(s) remaining
upload: ./cyclonedx.sbom.json to s3://***/pymongo-auth-aws/1.4.0.dev1/cyclonedx.sbom.json
Completed 620 Bytes/620 Bytes (1.7 KiB/s) with 1 file(s) remaining
upload: ./ssdlc_compliance_report.txt to s3://***/pymongo-auth-aws/1.4.0.dev1/ssdlc_compliance_report.txt
```