### PR TITLE
Fix handling of tag update

### DIFF
--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -25,6 +25,11 @@ jobs:
           # Needed to push the tag in the final step
           persist-credentials: true
 
+      - name: Set up git config
+        run: |
+          git config user.email "167856002+mongodb-dbx-release-bot[bot]@users.noreply.github.com"
+          git config user.name "mongodb-dbx-release-bot[bot]"
+
       - name: Remove the existing tag
         run: |
           export VERSION=$(cat .github/workflows/version.txt)


### PR DESCRIPTION
Fixes #90.  The only value we needed from the vault was GPG_KEY_ID, which we can store as an environment secret instead.