### PR TITLE
Opt into Node.js 24 for JavaScript actions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-dist:
     name: Check dist/

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   check-dist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test-typescript:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test-typescript:
     name: TypeScript Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 defaults:
   run:
     shell: bash -eux {0}

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   update-tag:

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -3,6 +3,9 @@ name: Update Tag
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   update-tag:
     name: Update Tag

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   zizmor:
     name: zizmor latest via Cargo

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,7 +7,7 @@ on:
     branches: ["**"]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   zizmor:

--- a/golang/pre-publish/action.yml
+++ b/golang/pre-publish/action.yml
@@ -32,6 +32,8 @@ runs:
       if: ${{ inputs.push_changes == 'true' && ! contains(fromJSON(inputs.ignored_branches), github.ref_name) }}
       id: get-next-branch
       uses: alcaeus/automatic-merge-up-action/get-next-branch@a43d2c2d3ed5a92a1fce3e3bde21c27c578f50d3 #1.0.0
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:
         ref: ${{ github.ref_name }}
         branchNamePattern: 'release/<major>.<minor>'

--- a/golang/pre-publish/action.yml
+++ b/golang/pre-publish/action.yml
@@ -33,7 +33,7 @@ runs:
       id: get-next-branch
       uses: alcaeus/automatic-merge-up-action/get-next-branch@a43d2c2d3ed5a92a1fce3e3bde21c27c578f50d3 #1.0.0
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         ref: ${{ github.ref_name }}
         branchNamePattern: 'release/<major>.<minor>'

--- a/node/setup/action.yml
+++ b/node/setup/action.yml
@@ -12,6 +12,8 @@ runs:
       with:
         node-version: "lts/*"
         registry-url: "https://registry.npmjs.org"
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - run: npm install -g npm@latest
       shell: bash
     - run: npm clean-install

--- a/node/setup/action.yml
+++ b/node/setup/action.yml
@@ -13,7 +13,7 @@ runs:
         node-version: "lts/*"
         registry-url: "https://registry.npmjs.org"
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - run: npm install -g npm@latest
       shell: bash
     - run: npm clean-install

--- a/node/sign_node_package/action.yml
+++ b/node/sign_node_package/action.yml
@@ -31,7 +31,7 @@ runs:
     - uses: actions/download-artifact@v4
       if: ${{ inputs.sign_native == 'true' }}
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - run: npm pack
       shell: bash

--- a/node/sign_node_package/action.yml
+++ b/node/sign_node_package/action.yml
@@ -30,6 +30,8 @@ runs:
   steps:
     - uses: actions/download-artifact@v4
       if: ${{ inputs.sign_native == 'true' }}
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - run: npm pack
       shell: bash

--- a/python-labs/post-publish/action.yml
+++ b/python-labs/post-publish/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         python-version: '3.11'
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Install hatch
       shell: bash
       run: pipx install hatch
@@ -43,7 +43,7 @@ runs:
         name: all-dist-${{ github.run_id }}
         path: dist/
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Get the package version
       shell: bash
       run: |

--- a/python-labs/post-publish/action.yml
+++ b/python-labs/post-publish/action.yml
@@ -32,6 +32,8 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Install hatch
       shell: bash
       run: pipx install hatch
@@ -40,6 +42,8 @@ runs:
       with:
         name: all-dist-${{ github.run_id }}
         path: dist/
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Get the package version
       shell: bash
       run: |

--- a/python-labs/pre-publish/action.yml
+++ b/python-labs/pre-publish/action.yml
@@ -25,6 +25,8 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Install hatch
       shell: bash
       working-directory: ${{ inputs.working_directory }}

--- a/python-labs/pre-publish/action.yml
+++ b/python-labs/pre-publish/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         python-version: '3.11'
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Install hatch
       shell: bash
       working-directory: ${{ inputs.working_directory }}

--- a/python/post-publish/action.yml
+++ b/python/post-publish/action.yml
@@ -43,6 +43,8 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Install hatch
       shell: bash
       run: pipx install hatch
@@ -51,6 +53,8 @@ runs:
       with:
         name: all-dist-${{ github.run_id }}
         path: dist/
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Ensure we have the package version
       shell: bash
       env:
@@ -105,11 +109,15 @@ runs:
       if: inputs.dry_run == 'false'
       with:
         subject-path: dist/*
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - uses: actions/attest-sbom@v1
       if: inputs.dry_run == 'false'
       with:
         subject-path: dist/*
         sbom-path: ${{ env.RELEASE_ASSETS }}/cyclonedx.sbom.json
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Ensure a clean repo
       shell: bash
       run: |

--- a/python/post-publish/action.yml
+++ b/python/post-publish/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         python-version: '3.11'
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Install hatch
       shell: bash
       run: pipx install hatch
@@ -54,7 +54,7 @@ runs:
         name: all-dist-${{ github.run_id }}
         path: dist/
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Ensure we have the package version
       shell: bash
       env:
@@ -110,14 +110,14 @@ runs:
       with:
         subject-path: dist/*
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - uses: actions/attest-sbom@v1
       if: inputs.dry_run == 'false'
       with:
         subject-path: dist/*
         sbom-path: ${{ env.RELEASE_ASSETS }}/cyclonedx.sbom.json
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Ensure a clean repo
       shell: bash
       run: |

--- a/python/pre-publish/action.yml
+++ b/python/pre-publish/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         python-version: '3.11'
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     - name: Install hatch
       shell: bash
       working-directory: ${{ inputs.working_directory }}

--- a/python/pre-publish/action.yml
+++ b/python/pre-publish/action.yml
@@ -30,6 +30,8 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     - name: Install hatch
       shell: bash
       working-directory: ${{ inputs.working_directory }}

--- a/ruby/build/action.yml
+++ b/ruby/build/action.yml
@@ -50,6 +50,8 @@ runs:
         rubygems: ${{ inputs.rubygems_version }}
         bundler-cache: true
         cache-version: ${{ inputs.bundler_cache_version }}
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - name: Get the release version
       id: release_version
@@ -81,3 +83,5 @@ runs:
         path: ${{ steps.gem_name.outputs.name }}
         retention-days: 1
         overwrite: true
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/ruby/build/action.yml
+++ b/ruby/build/action.yml
@@ -51,7 +51,7 @@ runs:
         bundler-cache: true
         cache-version: ${{ inputs.bundler_cache_version }}
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Get the release version
       id: release_version
@@ -84,4 +84,4 @@ runs:
         retention-days: 1
         overwrite: true
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/ruby/pr-check/action.yml
+++ b/ruby/pr-check/action.yml
@@ -25,6 +25,8 @@ runs:
       id: check_pr
       # 60a0d83039c74a4aee543508d2ffcb1c3799cdea => 'v7' tag as of 2025-07-28
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       with:
         script: |
           let pr;

--- a/ruby/pr-check/action.yml
+++ b/ruby/pr-check/action.yml
@@ -26,7 +26,7 @@ runs:
       # 60a0d83039c74a4aee543508d2ffcb1c3799cdea => 'v7' tag as of 2025-07-28
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         script: |
           let pr;

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -73,7 +73,7 @@ runs:
         bundler-cache: true
         cache-version: ${{ inputs.bundler_cache_version }}
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Get the release version
       id: release_version
@@ -93,7 +93,7 @@ runs:
       with:
         merge-multiple: true
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Sign the gems
       uses: mongodb-labs/drivers-github-tools/gpg-sign@v3
@@ -206,7 +206,7 @@ runs:
       with:
         await-release: false
       env:
-        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Publish the release
       if: inputs.dry_run == 'false'

--- a/ruby/publish/action.yml
+++ b/ruby/publish/action.yml
@@ -72,6 +72,8 @@ runs:
         rubygems: ${{ inputs.rubygems_version }}
         bundler-cache: true
         cache-version: ${{ inputs.bundler_cache_version }}
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - name: Get the release version
       id: release_version
@@ -90,6 +92,8 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         merge-multiple: true
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - name: Sign the gems
       uses: mongodb-labs/drivers-github-tools/gpg-sign@v3
@@ -201,6 +205,8 @@ runs:
       if: inputs.dry_run == 'false' && steps.gem_exists.outputs.exists == 'false'
       with:
         await-release: false
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     - name: Publish the release
       if: inputs.dry_run == 'false'

--- a/secure-checkout/action.yml
+++ b/secure-checkout/action.yml
@@ -28,6 +28,8 @@ runs:
         with:
           app-id: ${{ inputs.app_id }}
           private-key: ${{ inputs.private_key }}
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: Store GitHub token in environment
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
@@ -39,3 +41,5 @@ runs:
           token: ${{ env.GH_TOKEN }}
           fetch-depth: ${ {inputs.fetch-depth }}
           submodules: ${{ inputs.submodules }}
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/secure-checkout/action.yml
+++ b/secure-checkout/action.yml
@@ -29,7 +29,7 @@ runs:
           app-id: ${{ inputs.app_id }}
           private-key: ${{ inputs.private_key }}
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
       - name: Store GitHub token in environment
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
@@ -42,4 +42,4 @@ runs:
           fetch-depth: ${ {inputs.fetch-depth }}
           submodules: ${{ inputs.submodules }}
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -30,22 +30,30 @@ runs:
       role-to-assume: ${{ inputs.ecr_role_arn }}
       role-session-name: release-session
       aws-region: ${{ inputs.ecr_region }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   - name: Log in to ECR
     uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
     with:
       registries: "${{ inputs.ecr_registry_id }}"
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   - name: configure aws credentials
     uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
     with:
       role-to-assume: ${{ inputs.aws_role_arn }}
       role-session-name: release-session
       aws-region: ${{ inputs.aws_region_name }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   - name: Read secrets from AWS Secrets Manager into environment variables
     uses: aws-actions/aws-secretsmanager-get-secrets@5e19ff380d035695bdd56bbad320ca535c9063f2 # v2
     with:
       secret-ids: |
         ${{ inputs.aws_secret_id }}
       parse-json-secrets: true
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   - name: Set up
     shell: bash
     id: setup

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -31,13 +31,13 @@ runs:
       role-session-name: release-session
       aws-region: ${{ inputs.ecr_region }}
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   - name: Log in to ECR
     uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
     with:
       registries: "${{ inputs.ecr_registry_id }}"
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   - name: configure aws credentials
     uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
     with:
@@ -45,7 +45,7 @@ runs:
       role-session-name: release-session
       aws-region: ${{ inputs.aws_region_name }}
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   - name: Read secrets from AWS Secrets Manager into environment variables
     uses: aws-actions/aws-secretsmanager-get-secrets@5e19ff380d035695bdd56bbad320ca535c9063f2 # v2
     with:
@@ -53,7 +53,7 @@ runs:
         ${{ inputs.aws_secret_id }}
       parse-json-secrets: true
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   - name: Set up
     shell: bash
     id: setup


### PR DESCRIPTION
Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level in all 5 workflows.

GitHub Actions runners emit the following warning on current workflows:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-python@v5`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.
>
> To opt into Node.js 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file.
>
> https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This opts in early to validate there are no compatibility issues before the forced migration.