### PR TITLE
validate-submodules: skip regression check for unmodified submodules

### DIFF
--- a/validate-submodules/validate-submodules.sh
+++ b/validate-submodules/validate-submodules.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Validates that each submodule commit:
 #   1. Is on the upstream branch configured in .gitmodules
-#   2. Does not regress from the target branch of the PR (BASE_REF)
+#   2. Does not regress from the target branch of the PR (BASE_REF),
+#      but only if the PR actually changed the submodule
 #
 # Required env vars:
 #   REPO      - GitHub repository (e.g. "mongodb/mongo-php-library")
@@ -16,6 +17,10 @@ tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT
 gh api "repos/$REPO/contents/.gitmodules?ref=$PR_SHA" --jq '.content' | base64 -d > "$tmpfile"
 
+# Find the merge base between the PR and the target branch to detect which
+# submodules were actually changed by this PR
+merge_base=$(gh api "repos/$REPO/compare/$BASE_REF...$PR_SHA" --jq '.merge_base_commit.sha')
+
 while IFS=" " read -r key path; do
   name="${key#submodule.}"
   name="${name%.path}"
@@ -27,11 +32,13 @@ while IFS=" " read -r key path; do
 
   pr_sha=$(gh api "repos/$REPO/contents/$path?ref=$PR_SHA" --jq '.sha')
   base_sha=$(gh api "repos/$REPO/contents/$path?ref=$BASE_REF" --jq '.sha' 2>/dev/null || true)
+  merge_base_sha=$(gh api "repos/$REPO/contents/$path?ref=$merge_base" --jq '.sha' 2>/dev/null || true)
 
   echo "::group::Checking submodule: $name"
-  printf "  Repo:        %s\n" "$subrepo"
-  printf "  PR commit:   %s\n" "$pr_sha"
-  printf "  Base commit: %s\n" "${base_sha:-unknown}"
+  printf "  Repo:             %s\n" "$subrepo"
+  printf "  PR commit:        %s\n" "$pr_sha"
+  printf "  Base commit:      %s\n" "${base_sha:-unknown}"
+  printf "  Merge base commit:%s\n" "${merge_base_sha:-unknown}"
 
   # Check 1: pr_sha is on the upstream branch
   # "behind" or "identical" means pr_sha is an ancestor of the branch HEAD
@@ -43,9 +50,12 @@ while IFS=" " read -r key path; do
     errors=$((errors + 1))
   fi
 
-  # Check 2: pr_sha must not be older than the target branch's submodule commit
+  # Check 2: pr_sha must not be older than the target branch's submodule commit,
+  # but only if the PR actually changed the submodule (pr_sha differs from merge base).
+  # Skipping this check for unmodified submodules avoids false positives when the PR
+  # was created before the target branch advanced its submodule pointer.
   # "ahead" or "identical" means pr_sha is a descendant of base_sha
-  if [ -n "$base_sha" ] && [ "$base_sha" != "$pr_sha" ]; then
+  if [ -n "$base_sha" ] && [ "$base_sha" != "$pr_sha" ] && [ "$merge_base_sha" != "$pr_sha" ]; then
     status=$(gh api "repos/$subrepo/compare/$base_sha...$pr_sha?per_page=1" --jq '.status' 2>/dev/null || echo "error")
     if [ "$status" = "ahead" ] || [ "$status" = "identical" ]; then
       printf "  ✓ Moves forward from target branch (%s → %s)\n" "${base_sha:0:8}" "${pr_sha:0:8}"
@@ -53,6 +63,8 @@ while IFS=" " read -r key path; do
       echo "::error::Submodule '$name' regresses: target branch has $base_sha but PR has $pr_sha (status: $status)"
       errors=$((errors + 1))
     fi
+  elif [ "$merge_base_sha" = "$pr_sha" ]; then
+    echo "  ✓ Submodule not modified by this PR, skipping regression check"
   fi
 
   echo "::endgroup::"


### PR DESCRIPTION
## Summary

The regression check (Check 2) currently runs for all submodules whenever the PR's submodule SHA differs from the target branch's SHA. This causes false positives when the PR was created before the target branch advanced its submodule pointer — the PR hasn't touched that submodule, but it appears to "regress".

Fix: compute the merge base of the PR against the target branch, fetch the submodule SHA at that merge base, and only run the regression check when the PR actually changed the submodule (`pr_sha != merge_base_sha`).

Failing example: https://github.com/mongodb/mongo-php-library/actions/runs/26450505918/job/77869610297

## Scenarios

Variables: `common_ancestor_sha` = submodule SHA at the divergence point, `pr_sha` = submodule SHA in the PR, `target_sha` = submodule SHA at the tip of the target branch.

**Scenario 1 — PR does not change the submodule, but the target branch has advanced** *(the bug)*
- common_ancestor = A, pr = A, target = B (B > A)
- Old behavior: FAIL (A would regress from B)
- New behavior: SKIP (pr == common_ancestor, the PR did not touch the submodule) ✓

**Scenario 2 — PR advances the submodule normally**
- common_ancestor = A, pr = C (C > A), target = A or B (B ≤ C)
- New behavior: CHECK → PASS ✓

**Scenario 3 — PR actually regresses the submodule** *(real regression to detect)*
- common_ancestor = A, pr = B (B < A or diverged), target = C (C > B)
- New behavior: CHECK → FAIL ✓

**Scenario 4 — PR and target branch are at the same point** *(steady state)*
- common_ancestor = A, pr = A, target = A
- New behavior: SKIP (target == pr) ✓

**Scenario 5 — PR advances the submodule, target branch also advanced but less**
- common_ancestor = A, pr = C, target = B (A < B < C)
- New behavior: CHECK → PASS ✓

**Scenario 6 — PR advances the submodule, but target branch advanced further** *(real regression)*
- common_ancestor = A, pr = B, target = C (A < B, A < C, B < C or B diverged)
- New behavior: CHECK → FAIL ✓