### PR TITLE
Add documentation for the validate-submodules action

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,27 @@ prerelease version, and push the changes.
     evergreen_project: <name of evergreen release project>
 ```
 
+### Validate Submodules
+
+Use this action to validate that submodule commits are present on the upstream
+branch and do not regress from the target branch. It is intended to run on
+pull requests and merge groups.
+
+```yaml
+on:
+  merge_group:
+  pull_request:
+
+jobs:
+  validate-submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate submodule commits
+        uses: mongodb-labs/drivers-github-tools/validate-submodules@v3
+        with:
+          token: ${{ github.token }}
+```
+
 ## Python Helper Scripts
 
 These scripts are opinionated helper scripts for Python releases.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,16 @@ Use this action to validate that submodule commits are present on the upstream
 branch and do not regress from the target branch. It is intended to run on
 pull requests and merge groups.
 
+Each submodule entry in `.gitmodules` must declare a `branch` field pointing
+to the upstream branch to validate against:
+
+```ini
+[submodule "specifications"]
+	path = tests/specifications
+	url = https://github.com/mongodb/specifications
+	branch = master
+```
+
 ```yaml
 on:
   merge_group:


### PR DESCRIPTION
Documents the `validate-submodules` action in the README, including the requirement to declare a `branch` field in `.gitmodules` for each submodule.