### PR TITLE
DRIVERS-3546 Embed PGP public key URL in signed commit and tag messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           MSG=$(git log -1 --format=%B)
           echo "$MSG"
           if [ "$EXPECT_PGP_KEY" = "true" ]; then
-            echo "$MSG" | grep -q "PGP-Key: $GPG_PUBLIC_URL"
+            echo "$MSG" | grep -q "PGP-Signing-Key: $GPG_PUBLIC_URL"
           else
             ! echo "$MSG" | grep -q "PGP-Key:"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test-gpg-key-commit-message:
-    name: Test GPG-Key commit message format
+    name: Test PGP-Key commit message format
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,16 +41,16 @@ jobs:
           echo "test" >> test_file.txt
           git add test_file.txt
           git commit -m "BUMP 1.0.0" \
-            ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} \
+            ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} \
             -s
       - name: Verify commit message format
         run: |
           MSG=$(git log -1 --format=%B)
           echo "$MSG"
           if [ "${{ matrix.expect_gpg_key }}" = "true" ]; then
-            echo "$MSG" | grep -q "GPG-Key: $GPG_PUBLIC_URL"
+            echo "$MSG" | grep -q "PGP-Key: $GPG_PUBLIC_URL"
           else
-            ! echo "$MSG" | grep -q "GPG-Key:"
+            ! echo "$MSG" | grep -q "PGP-Key:"
           fi
 
   test-typescript:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,14 @@ jobs:
           git config user.email "test@example.com"
           git config user.name "Test"
       - name: Make a commit using the same message flags as bump-version
-        env:
-          PGP_KEY_ARGS: "${{ env.GPG_PUBLIC_URL != '' && format('-m \"PGP-Key: {0}\"', env.GPG_PUBLIC_URL) || '' }}"
         run: |
           echo "test" >> test_file.txt
           git add test_file.txt
-          git commit -m "BUMP 1.0.0" $PGP_KEY_ARGS -s
+          if [ -n "$GPG_PUBLIC_URL" ]; then
+            git commit -m "BUMP 1.0.0" -m "PGP-Key: $GPG_PUBLIC_URL" -s
+          else
+            git commit -m "BUMP 1.0.0" -s
+          fi
       - name: Verify commit message format
         env:
           EXPECT_PGP_KEY: ${{ matrix.expect_gpg_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,44 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  test-gpg-key-commit-message:
+    name: Test GPG-Key commit message format
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - gpg_public_url: "https://pgp.mongodb.com/python-driver.pub"
+            expect_gpg_key: "true"
+          - gpg_public_url: ""
+            expect_gpg_key: "false"
+    env:
+      GPG_PUBLIC_URL: ${{ matrix.gpg_public_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Configure git
+        run: |
+          git config user.email "test@example.com"
+          git config user.name "Test"
+      - name: Make a commit using the same message flags as bump-version
+        run: |
+          echo "test" >> test_file.txt
+          git add test_file.txt
+          git commit -m "BUMP 1.0.0" \
+            ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} \
+            -s
+      - name: Verify commit message format
+        run: |
+          MSG=$(git log -1 --format=%B)
+          echo "$MSG"
+          if [ "${{ matrix.expect_gpg_key }}" = "true" ]; then
+            echo "$MSG" | grep -q "GPG-Key: $GPG_PUBLIC_URL"
+          else
+            ! echo "$MSG" | grep -q "GPG-Key:"
+          fi
+
   test-typescript:
     name: TypeScript Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,48 +15,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  test-gpg-key-commit-message:
-    name: Test PGP-Key commit message format
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - gpg_public_url: "https://pgp.mongodb.com/python-driver.pub"
-            expect_gpg_key: "true"
-          - gpg_public_url: ""
-            expect_gpg_key: "false"
-    env:
-      GPG_PUBLIC_URL: ${{ matrix.gpg_public_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Configure git
-        run: |
-          git config user.email "test@example.com"
-          git config user.name "Test"
-      - name: Make a commit using the same message flags as bump-version
-        run: |
-          echo "test" >> test_file.txt
-          git add test_file.txt
-          if [ -n "$GPG_PUBLIC_URL" ]; then
-            git commit -m "BUMP 1.0.0" -m "PGP-Signing-Key: $GPG_PUBLIC_URL" -s
-          else
-            git commit -m "BUMP 1.0.0" -s
-          fi
-      - name: Verify commit message format
-        env:
-          EXPECT_PGP_KEY: ${{ matrix.expect_gpg_key }}
-        run: |
-          MSG=$(git log -1 --format=%B)
-          echo "$MSG"
-          if [ "$EXPECT_PGP_KEY" = "true" ]; then
-            echo "$MSG" | grep -q "PGP-Signing-Key: $GPG_PUBLIC_URL"
-          else
-            ! echo "$MSG" | grep -q "PGP-Key:"
-          fi
-
   test-typescript:
     name: TypeScript Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           echo "test" >> test_file.txt
           git add test_file.txt
           if [ -n "$GPG_PUBLIC_URL" ]; then
-            git commit -m "BUMP 1.0.0" -m "PGP-Key: $GPG_PUBLIC_URL" -s
+            git commit -m "BUMP 1.0.0" -m "PGP-Signing-Key: $GPG_PUBLIC_URL" -s
           else
             git commit -m "BUMP 1.0.0" -s
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,19 @@ jobs:
           git config user.email "test@example.com"
           git config user.name "Test"
       - name: Make a commit using the same message flags as bump-version
+        env:
+          PGP_KEY_ARGS: "${{ env.GPG_PUBLIC_URL != '' && format('-m \"PGP-Key: {0}\"', env.GPG_PUBLIC_URL) || '' }}"
         run: |
           echo "test" >> test_file.txt
           git add test_file.txt
-          git commit -m "BUMP 1.0.0" \
-            ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} \
-            -s
+          git commit -m "BUMP 1.0.0" $PGP_KEY_ARGS -s
       - name: Verify commit message format
+        env:
+          EXPECT_PGP_KEY: ${{ matrix.expect_gpg_key }}
         run: |
           MSG=$(git log -1 --format=%B)
           echo "$MSG"
-          if [ "${{ matrix.expect_gpg_key }}" = "true" ]; then
+          if [ "$EXPECT_PGP_KEY" = "true" ]; then
             echo "$MSG" | grep -q "PGP-Key: $GPG_PUBLIC_URL"
           else
             ! echo "$MSG" | grep -q "PGP-Key:"

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -39,7 +39,7 @@ runs:
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
         command: |-
-          git commit -a -m "${{ env.COMMIT_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --gpg-sign=${{ env.GPG_KEY_ID }}
+          git commit -a -m "${{ env.COMMIT_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Signing-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --gpg-sign=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Push the commit to the source branch
       shell: bash -eux {0}

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -39,7 +39,7 @@ runs:
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
         command: |-
-          git commit -a -m "${{ env.COMMIT_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --gpg-sign=${{ env.GPG_KEY_ID }}
+          git commit -a -m "${{ env.COMMIT_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --gpg-sign=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Push the commit to the source branch
       shell: bash -eux {0}

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -38,7 +38,8 @@ runs:
     - name: Commit the version bump
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
-        command: git commit -a -m "${{ env.COMMIT_MESSAGE }}" -s --gpg-sign=${{ env.GPG_KEY_ID }}
+        command: |-
+          git commit -a -m "${{ env.COMMIT_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --gpg-sign=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Push the commit to the source branch
       shell: bash -eux {0}

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -36,7 +36,7 @@ runs:
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
         command: |-
-          git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --local-user=${{ env.GPG_KEY_ID }}
+          git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Signing-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --local-user=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Verify the tag
       shell: bash -eux {0}

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -35,7 +35,8 @@ runs:
     - name: Tag the version
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
-        command: git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" -s --local-user=${{ env.GPG_KEY_ID }}
+        command: |-
+          git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --local-user=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Verify the tag
       shell: bash -eux {0}

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -36,7 +36,7 @@ runs:
       uses: mongodb-labs/drivers-github-tools/git-sign@v3
       with:
         command: |-
-          git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "GPG-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --local-user=${{ env.GPG_KEY_ID }}
+          git tag -a "${{ env.TAG }}" -m "${{ env.TAG_MESSAGE }}" ${{ env.GPG_PUBLIC_URL != '' && format('-m "PGP-Key: {0}"', env.GPG_PUBLIC_URL) || '' }} -s --local-user=${{ env.GPG_KEY_ID }}
         ecr_repository: ${{ inputs.ecr_repository }}
     - name: Verify the tag
       shell: bash -eux {0}


### PR DESCRIPTION
DRIVERS-3546

## Summary

When `GPG_PUBLIC_URL` is configured, signed commit and tag messages now include a `PGP-Signing-Key: <url>` line in the body. This allows anyone to fetch the public key and independently verify the signature using standard git tooling, since GitHub cannot display Garasign-signed commits as "Verified" for bot accounts.

When `GPG_PUBLIC_URL` is not set, messages are unchanged.

Also adds a CI test covering both cases.