### PR TITLE
PYTHON-5877 Add codeql composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ There are several ways to specify the security report:
 ### CodeQL Analysis
 
 This action runs CodeQL analysis for a single language. It includes checkout,
-Python setup, CodeQL initialization, an optional manual build step, and the
+language setup, CodeQL initialization, an optional manual build step, and the
 analysis itself — centralising the pinned CodeQL action version so Dependabot
-only needs to update one file across all drivers.
+only needs to update one file across all repos using the action.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -257,9 +257,10 @@ There are several ways to specify the security report:
 ### CodeQL Analysis
 
 This action runs CodeQL analysis for a single language. It includes checkout,
-language setup, CodeQL initialization, an optional manual build step, and the
-analysis itself — centralising the pinned CodeQL action version so Dependabot
-only needs to update one file across all repos using the action.
+Python setup (only when `language: python`), CodeQL initialization, an optional
+manual build step, and the analysis itself — centralising the pinned CodeQL
+action version so Dependabot only needs to update one file across all repos
+using the action.
 
 ```yaml
 jobs:
@@ -272,35 +273,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: c-cpp
-          build-mode: manual
-          manual-build-command: make
-        - language: python
-          build-mode: none
-        - language: actions
-          build-mode: none
+          - language: cpp
+            build-mode: manual
+            manual-build-command: make
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
     steps:
-    - uses: mongodb-labs/drivers-github-tools/codeql@v3
-      with:
-        language: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        manual-build-command: ${{ matrix.manual-build-command }}
-        config: |
-          paths-ignore:
-            - 'doc/**'
-            - 'test/**'
+      - uses: mongodb-labs/drivers-github-tools/codeql@v3
+        with:
+          language: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          manual-build-command: ${{ matrix.manual-build-command }}
+          config: |
+            paths-ignore:
+              - 'doc/**'
+              - 'test/**'
 ```
 
 Pass `ref` when the workflow is invoked via `workflow_call` with a specific git
 ref:
 
 ```yaml
-    - uses: mongodb-labs/drivers-github-tools/codeql@v3
-      with:
-        language: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        manual-build-command: ${{ matrix.manual-build-command }}
-        ref: ${{ inputs.ref }}
+      - uses: mongodb-labs/drivers-github-tools/codeql@v3
+        with:
+          language: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          manual-build-command: ${{ matrix.manual-build-command }}
+          ref: ${{ inputs.ref }}
 ```
 
 ## Other Common Actions

--- a/README.md
+++ b/README.md
@@ -252,6 +252,54 @@ There are several ways to specify the security report:
 - By specifying a relative path, which is then linked to the corresponding git blob for the tagged version
 - By adding the `security-report-url` to the AWS Secrets Vault
 
+## Security Actions
+
+### CodeQL Analysis
+
+This action runs CodeQL analysis for a single language. It includes checkout,
+Python setup, CodeQL initialization, an optional manual build step, and the
+analysis itself — centralising the pinned CodeQL action version so Dependabot
+only needs to update one file across all drivers.
+
+```yaml
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: manual
+        - language: python
+          build-mode: none
+        - language: actions
+          build-mode: none
+    steps:
+    - uses: mongodb-labs/drivers-github-tools/codeql@v3
+      with:
+        language: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        config: |
+          paths-ignore:
+            - 'doc/**'
+            - 'test/**'
+```
+
+Pass `ref` when the workflow is invoked via `workflow_call` with a specific git
+ref:
+
+```yaml
+    - uses: mongodb-labs/drivers-github-tools/codeql@v3
+      with:
+        language: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        ref: ${{ inputs.ref }}
+```
+
 ## Other Common Actions
 
 ### Full Report

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ jobs:
         include:
         - language: c-cpp
           build-mode: manual
+          manual-build-command: make
         - language: python
           build-mode: none
         - language: actions
@@ -283,6 +284,7 @@ jobs:
       with:
         language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        manual-build-command: ${{ matrix.manual-build-command }}
         config: |
           paths-ignore:
             - 'doc/**'
@@ -297,6 +299,7 @@ ref:
       with:
         language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        manual-build-command: ${{ matrix.manual-build-command }}
         ref: ${{ inputs.ref }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ jobs:
     timeout-minutes: 360
     permissions:
       security-events: write
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -59,6 +59,12 @@ runs:
         fi
         bash -c "$MANUAL_BUILD_COMMAND"
 
+    - if: ${{ inputs.build-mode == 'autobuild' }}
+      name: Autobuild
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       env:

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -3,7 +3,7 @@ description: Run CodeQL analysis for a single language.
 
 inputs:
   language:
-    description: Language to analyze (e.g. c-cpp, python, actions, javascript).
+    description: Language to analyze (e.g. cpp, python, actions, javascript).
     required: true
   build-mode:
     description: Build mode for CodeQL (none, manual, autobuild).
@@ -26,16 +26,19 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
 
-    - uses: actions/setup-python@v5
+    - if: ${{ inputs.language == 'python' }}
+      uses: actions/setup-python@v5
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
@@ -57,7 +60,7 @@ runs:
         bash -c "$MANUAL_BUILD_COMMAND"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -8,6 +8,9 @@ inputs:
   build-mode:
     description: Build mode for CodeQL (none, manual, autobuild).
     default: none
+  manual-build-command:
+    description: Shell command to run when build-mode is manual.
+    default: ''
   ref:
     description: Git ref to check out. Leave empty to use the default checkout behavior.
     default: ''
@@ -22,12 +25,12 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -40,7 +43,7 @@ runs:
     - if: ${{ inputs.build-mode == 'manual' }}
       name: Build
       shell: bash
-      run: pip install -e .
+      run: ${{ inputs.manual-build-command }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -1,0 +1,48 @@
+name: CodeQL Analysis
+description: Run CodeQL analysis for a single language.
+
+inputs:
+  language:
+    description: Language to analyze (e.g. c-cpp, python, actions, javascript).
+    required: true
+  build-mode:
+    description: Build mode for CodeQL (none, manual, autobuild).
+    default: none
+  ref:
+    description: Git ref to check out. Leave empty to use the default checkout behavior.
+    default: ''
+  queries:
+    description: CodeQL query suite to run.
+    default: security-extended
+  config:
+    description: Inline CodeQL YAML configuration (e.g. a paths-ignore block).
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6.0.3
+      with:
+        ref: ${{ inputs.ref }}
+        persist-credentials: false
+
+    - uses: actions/setup-python@v6
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      with:
+        languages: ${{ inputs.language }}
+        build-mode: ${{ inputs.build-mode }}
+        queries: ${{ inputs.queries }}
+        config: ${{ inputs.config }}
+
+    - if: ${{ inputs.build-mode == 'manual' }}
+      name: Build
+      shell: bash
+      run: pip install -e .
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      with:
+        category: "/language:${{ inputs.language }}"

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -31,9 +31,13 @@ runs:
         persist-credentials: false
 
     - uses: actions/setup-python@v5
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         languages: ${{ inputs.language }}
         build-mode: ${{ inputs.build-mode }}
@@ -43,9 +47,18 @@ runs:
     - if: ${{ inputs.build-mode == 'manual' }}
       name: Build
       shell: bash
-      run: ${{ inputs.manual-build-command }}
+      env:
+        MANUAL_BUILD_COMMAND: ${{ inputs.manual-build-command }}
+      run: |
+        if [ -z "$MANUAL_BUILD_COMMAND" ]; then
+          echo "::error::build-mode is 'manual' but no manual-build-command was provided." >&2
+          exit 1
+        fi
+        bash -c "$MANUAL_BUILD_COMMAND"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         category: "/language:${{ inputs.language }}"

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: Shell command to run when build-mode is manual.
     default: ''
   ref:
-    description: Git ref to check out. Leave empty to use the default checkout behavior.
+    description: Git ref to check out. Leave empty to fall back to github.ref (the triggering ref).
     default: ''
   queries:
     description: CodeQL query suite to run.
@@ -29,7 +29,7 @@ runs:
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
-        ref: ${{ inputs.ref }}
+        ref: ${{ inputs.ref || github.ref }}
         persist-credentials: false
 
     - if: ${{ inputs.language == 'python' }}


### PR DESCRIPTION
## Summary

- Adds a `codeql` composite action that encapsulates the full CodeQL analysis workflow (checkout, Python setup, init, optional manual build, analyze) for a single language.
- Centralises the pinned `github/codeql-action` hash so Dependabot only needs to update one file across all drivers instead of every repo independently.

## Test Plan

- Pre-commit hooks (Validate GitHub Actions) passed on commit.
- The composite action is consumed by the companion mongo-python-driver PR ([PYTHON-5877](https://github.com/mongodb/mongo-python-driver/pull/2883)), which runs the existing CodeQL workflow unchanged end-to-end.