### PR TITLE
Fix Dependabot to scan nested action.yml files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,10 @@ version: 2
 updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/*"
+      - "/*/*"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Summary
- Dependabot was only scanning `.github/workflows` and a (non-existent) root-level `action.yml`, so third-party actions used inside our nested composite actions (e.g. `tag-version/action.yml`, `node/setup/action.yml`) were never checked for updates.
- Expanded the config to cover those subdirectories so Dependabot can open update PRs for them too.

## Test plan
- [x] Validated the config against the Dependabot schema using `pre-commit`
- [ ] Confirm Dependabot opens PRs for nested actions after this merges (will need to wait until after merging).