### PR TITLE
PYTHON-5980 Handle exclude-newer in the uv lock update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,9 +504,7 @@ This action runs `uv lock --upgrade` and opens a pull request with the resulting
 lock file changes. It maintains a single open pull request: a subsequent run
 updates the existing one rather than opening a second.
 
-The caller checks out the repository and puts `uv` on `PATH`. The cooldown on new
-releases comes from `exclude-newer` in the consuming repo's `pyproject.toml`, not
-from this action.
+The caller checks out the repository and puts `uv` on `PATH`.
 
 ```yaml
 name: Update uv.lock
@@ -547,6 +545,23 @@ GitHub rejects a pull request that asks for an unknown one.
 
 Set `dry_run: true` to log the branch and pull request the action would have
 created, without pushing or opening anything.
+
+The upgrade skips releases published within the last 7 days, so a broken or
+compromised release has time to be yanked before it can land in the lock file.
+Change the cutoff with `exclude_newer`, which takes anything uv's
+`--exclude-newer` accepts: a date, an RFC 3339 timestamp, a duration such as
+`30 days`, or `false` to upgrade to the newest releases with no cutoff at all.
+It reaches uv as `UV_EXCLUDE_NEWER`, so it overrides an `exclude-newer` the
+repository sets in `pyproject.toml` or `uv.toml`. Set it to an empty string to
+leave that setting in charge instead.
+
+```yaml
+      - uses: mongodb-labs/drivers-github-tools/python/uv-lock-update@v3
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          exclude_newer: 14 days
+```
 
 ## Python Labs Helper Scripts
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Change the cutoff with `exclude_newer`, which takes anything uv's
 `--exclude-newer` accepts: a date, an RFC 3339 timestamp, a duration such as
 `30 days`, or `false` to upgrade to the newest releases with no cutoff at all.
 It reaches uv as `UV_EXCLUDE_NEWER`, so it overrides an `exclude-newer` the
-repository sets in `pyproject.toml` or `uv.toml`. Set it to an empty string to
+repository sets in `pyproject.toml` or `uv.toml`. Pass `exclude_newer: ""` to
 leave that setting in charge instead.
 
 ```yaml

--- a/python/uv-lock-update/action.yml
+++ b/python/uv-lock-update/action.yml
@@ -71,10 +71,14 @@ runs:
         EXCLUDE_NEWER: ${{ inputs.exclude_newer }}
       run: |
         # UV_EXCLUDE_NEWER outranks the project's uv configuration, and uv
-        # rejects it when empty, so an empty input has to leave it unset rather
-        # than be passed through.
+        # rejects it when empty, so an empty input clears the variable rather
+        # than passing the empty value through. Clearing it also drops any
+        # UV_EXCLUDE_NEWER the caller's workflow exported, so the input alone
+        # decides the cutoff.
         if [ -n "$EXCLUDE_NEWER" ]; then
           export UV_EXCLUDE_NEWER="$EXCLUDE_NEWER"
+        else
+          unset UV_EXCLUDE_NEWER
         fi
         uv lock --upgrade
 

--- a/python/uv-lock-update/action.yml
+++ b/python/uv-lock-update/action.yml
@@ -21,6 +21,14 @@ inputs:
   dry_run:
     description: If 'true', report intended actions without pushing or modifying pull requests
     default: "false"
+  exclude_newer:
+    description: >-
+      Cutoff passed to uv as UV_EXCLUDE_NEWER, so the upgrade ignores releases
+      published after it. Accepts anything uv's --exclude-newer does: a date, an
+      RFC 3339 timestamp, a duration such as '30 days', or 'false' to disable the
+      cutoff. Set it to an empty string to leave the cutoff to the project's own
+      uv configuration.
+    default: 7 days
 
 runs:
   using: composite
@@ -60,7 +68,16 @@ runs:
 
     - name: Upgrade the lock file
       shell: bash
-      run: uv lock --upgrade
+      env:
+        EXCLUDE_NEWER: ${{ inputs.exclude_newer }}
+      run: |
+        # UV_EXCLUDE_NEWER outranks the project's uv configuration, and uv
+        # rejects it when empty, so an empty input has to leave it unset rather
+        # than be passed through.
+        if [ -n "$EXCLUDE_NEWER" ]; then
+          export UV_EXCLUDE_NEWER="$EXCLUDE_NEWER"
+        fi
+        uv lock --upgrade
 
     - name: Create or update the pull request
       shell: bash

--- a/python/uv-lock-update/action.yml
+++ b/python/uv-lock-update/action.yml
@@ -26,8 +26,7 @@ inputs:
       Cutoff passed to uv as UV_EXCLUDE_NEWER, so the upgrade ignores releases
       published after it. Accepts anything uv's --exclude-newer does: a date, an
       RFC 3339 timestamp, a duration such as '30 days', or 'false' to disable the
-      cutoff. Set it to an empty string to leave the cutoff to the project's own
-      uv configuration.
+      cutoff. Pass "" to leave the cutoff to the project's own uv configuration.
     default: 7 days
 
 runs:


### PR DESCRIPTION
## Summary

Adds a 7 day cutoff on new releases in the uv lock update action, overridable through an `exclude_newer` input.

## Motivation

Prior to this change, a scheduled update would include every release the moment it lands, including one yanked hours later as broken or compromised. A week of distance means a bad release is usually withdrawn first.

## Changes

- `exclude_newer` input, defaulting to `7 days` and reaching uv as `UV_EXCLUDE_NEWER`. It takes anything uv's `--exclude-newer` does: a date, an RFC 3339 timestamp, a duration such as `30 days`, or `false` to disable the cutoff.
- An empty input leaves `UV_EXCLUDE_NEWER` unset, so a repository can keep the cutoff in its own uv configuration. uv rejects the variable when it is set but empty, so this case has to be handled rather than passed through.

## Testing

Ran the resulting step against uv 0.12 both ways: `7 days` locks with `exclude-newer-span = "P7D"`, and an empty value locks with no cutoff recorded.
