### PR TITLE
Grant `secure-checkout` pull-request write access

### DIFF
--- a/secure-checkout/action.yml
+++ b/secure-checkout/action.yml
@@ -29,6 +29,7 @@ runs:
           app-id: ${{ inputs.app_id }}
           private-key: ${{ inputs.private_key }}
           permission-contents: write
+          permission-pull-requests: write
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 


### PR DESCRIPTION
`secure-checkout` [documents](https://github.com/mongodb-labs/drivers-github-tools/tree/54ab7b98577fc59acb78856e7e3903da23f5d0fe#secure-checkout):

> It will write the secure global variable `GH_TOKEN` that can be used with the `gh` cli.

A recent change [added](https://github.com/mongodb-labs/drivers-github-tools/pull/110/changes#diff-c19011a32d4cf4f04a0089ef86511e3ce1c2493d4c25697e1625f27c7abf8a13R31) `permission-contents: write` to `secure-checkout`. I expect that reduced the permissions of the created token. This permission changes appears to have broken workflows that try to create a PR: https://github.com/mongodb/mongo-php-library/actions/runs/32268117090. This appears to affect workflows in PHP and Go.

I expect we can fix this in affected workflows by creating a separate token. But since this is used by PHP and Go projects, and the README documents using the token for `gh`, I expect this may more appropriately fixed here.

To test: I used a [temporary branch](https://github.com/mongodb/mongo-php-driver/commit/f48677daad20358bb1d5554981e526c7bba1d40c) to run the workflow from my fork, which successfully drafted a [PR](https://github.com/mongodb/mongo-php-driver/pull/2050).